### PR TITLE
Upgrade TailwindUI for TailwindCSS 2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2597,34 +2597,26 @@
         "loader-utils": "^2.0.0"
       }
     },
-    "@tailwindcss/custom-forms": {
+    "@tailwindcss/aspect-ratio": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.0.tgz",
+      "integrity": "sha512-v5LyHkwXj/4lI74B06zUrmWEdmSqS43+jw717pkt3fAXqb7ALwu77A8t7j+Bej+ZbdlIIqNMYheGN7wSGV1A6w==",
+      "dev": true
+    },
+    "@tailwindcss/forms": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/custom-forms/-/custom-forms-0.2.1.tgz",
-      "integrity": "sha512-XdP5XY6kxo3x5o50mWUyoYWxOPV16baagLoZ5uM41gh6IhXzhz/vJYzqrTb/lN58maGIKlpkxgVsQUNSsbAS3Q==",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.2.1.tgz",
+      "integrity": "sha512-czfvEdY+J2Ogfd6RUSr/ZSUmDxTujr34M++YLnp2cCPC3oJ4kFvFMaRXA6cEXKw7F1hJuapdjXRjsXIEXGgORg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11",
-        "mini-svg-data-uri": "^1.0.3",
-        "traverse": "^0.6.6"
+        "mini-svg-data-uri": "^1.2.3"
       }
     },
     "@tailwindcss/typography": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.2.0.tgz",
-      "integrity": "sha512-aPgMH+CjQiScLZculoDNOQUrrK2ktkbl3D6uCLYp1jgYRlNDrMONu9nMu8LfwAeetYNpVNeIGx7WzHSu0kvECg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.3.1.tgz",
+      "integrity": "sha512-HyZ+3Eay8SGaPq7kcFoANZLr4EjeXQ19yjjb9fp6B0PHHpvZoe00jdsnpnooMEbx9J5rQ93nxPUG3MQmXVxGMQ==",
       "dev": true
-    },
-    "@tailwindcss/ui": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/ui/-/ui-0.7.2.tgz",
-      "integrity": "sha512-7HuFoWUMfVdY8EWEIS2FSJBCj+iEWL4JfljVE6Wd5qLrQrCzH10tuE0S6697jPm7dt8ZUEslFWlJtAsU76A5Nw==",
-      "dev": true,
-      "requires": {
-        "@tailwindcss/custom-forms": "^0.2.1",
-        "@tailwindcss/typography": "^0.2.0",
-        "hex-rgb": "^4.1.0",
-        "postcss-selector-parser": "^6.0.2"
-      }
     },
     "@testing-library/dom": {
       "version": "6.16.0",
@@ -8251,12 +8243,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
-    },
-    "hex-rgb": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.2.0.tgz",
-      "integrity": "sha512-I7DkKeQ2kR2uyqgbxPgNgClH/rfs1ioKZhZW8VTIAirsxCR5EyhYeywgZbhMScgUbKCkgo6bb6JwA0CLTn9beA==",
-      "dev": true
     },
     "history": {
       "version": "4.10.1",
@@ -19548,12 +19534,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
     },
     "tryer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   },
   "devDependencies": {
     "@headlessui/react": "^0.2.0",
-    "@tailwindcss/ui": "^0.7.2",
+    "@tailwindcss/aspect-ratio": "^0.2.0",
+    "@tailwindcss/forms": "^0.2.1",
+    "@tailwindcss/typography": "^0.3.1",
     "autoprefixer": "^10.0.2",
     "postcss": "^8.1.7",
     "postcss-cli": "^8.3.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,8 @@ module.exports = {
   },
   variants: {},
   plugins: [
-    require('@tailwindcss/ui'),
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/aspect-ratio'),
   ],
 }


### PR DESCRIPTION
- Follow upgrade [doc](https://tailwindui.com/changes-for-v2#updating-your-tailwind-ui-projects) for TailwindUI to use TailwindCSS 2.x
- removed `@tailwindcss/ui` - **DEPRECATED**