### PR TITLE
Tailwind - remove now unnecessary default extractor

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,5 @@
 module.exports = {
-  purge: {
-    content: ['./public/index.html', './src/**/*.js', './src/**/*.jsx'],
-    options: {
-      // using TailwindUI extractor => https://tailwindui.com/documentation
-      defaultExtractor: (content) => content.match(/[\w-/.:]+(?<!:)/g) || [],
-    },
-  },
+  purge: ['./public/index.html', './src/**/*.js', './src/**/*.jsx'],
   theme: {
     extend: {
       height: {


### PR DESCRIPTION
- Tailwind 2.x now comes with default extractor built in; removing old settings to prevent confusion & simplify config