### PR TITLE
Push all logout to index page

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -29,6 +29,7 @@ import { AUTH_API, GRAPHQL_API, VERIFY_API } from 'config'
 import { GET_BARISTA } from 'queries'
 import { updates, keys } from 'helper/cache'
 import { print } from 'graphql'
+import { useHistory } from 'react-router-dom'
 
 const AuthContext = createContext()
 
@@ -80,11 +81,14 @@ function AuthProvider({ children }) {
 
   const [state, dispatch] = useReducer(reducer, initialState)
 
+  const history = useHistory()
+
   const logout = useCallback(async () => {
     await logoutAPI()
     dispatch(['logout'])
+    history.push('/')
     console.log('%cLogged out!', 'color:purple')
-  }, [])
+  }, [history])
 
   // use after another page triggers email confirmation
   const setVerifiedStatus = useCallback(() => {
@@ -115,9 +119,10 @@ function AuthProvider({ children }) {
     // to logout, thus all they need is to dispatch action as
     // localstorage is cleared & cookie is cleared for them in
     // the active tab
-    const syncLogout = async (event) => {
+    const syncLogout = (event) => {
       if (event.key === 'logout') {
         dispatch(['logout'])
+        history.push('/')
         console.log('%cLogged out!', 'color:pink')
       }
     }


### PR DESCRIPTION
# Note
With all the complications with different verification behavior and things you can do depending on if you are logged in or verified, it became apparent that their are some intermediate form steps that would be weirdly exposed if you were to log out in the middle and not get pushed to a clean state. 

Home page push is the cleanest/simplest workflow right now