### PR TITLE
Fix hard to track bug with refresh token

### DIFF
--- a/src/helper/auth.js
+++ b/src/helper/auth.js
@@ -8,7 +8,7 @@ export const logoutAPI = async () => {
   localStorage.clear()
 
   // remove refresh token cookie
-  await axios.post(AUTH_API + '/logout', { withCredentials: true })
+  await axios.post(AUTH_API + '/logout', null, { withCredentials: true })
 }
 
 export const getTokenFromRefresh = async () => {


### PR DESCRIPTION
# Bug fix
- refresh tokens kept being made because they weren't being deleted in `/logout` endpoint
- **CAUSE** - code for posting to endpoint was `await axios.post(AUTH_API + '/logout', { withCredentials: true })` which missed a required `null` body to be able to send with cookies, thus no cookie was received in the logout controller this whole time