### PR TITLE
Disable react dev tools for prod/stage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,18 @@ import { AlertProvider } from 'context/AlertContext'
 import { AuthProvider } from 'context/AuthContext'
 import { ModalProvider } from 'context/ModalContext'
 
+if (process.env.NODE_ENV === 'production') {
+  // disable react-dev-tools for this project
+  if (typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === 'object') {
+    for (let [key, value] of Object.entries(
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__
+    )) {
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[key] =
+        typeof value == 'function' ? () => {} : null
+    }
+  }
+}
+
 ReactDOM.render(
   <StrictMode>
     <Router>


### PR DESCRIPTION
- disables react devtool in production and stage environment (stage.brewbean.io runs with `NODE_ENV=production`)

Closes #158