### PR TITLE
Recipe name unique by user UI error handling

### DIFF
--- a/src/components/Recipe/Form/index.js
+++ b/src/components/Recipe/Form/index.js
@@ -260,7 +260,9 @@ export default function Form({
         </Link>
         <button
           type='submit'
-          disabled={formMounted && !isHidden}
+          disabled={
+            (formMounted && !isHidden) || Object.keys(errors).length > 0
+          }
           className={`disabled:opacity-50 disabled:pointer-events-none ml-3 btn btn--md btn--primary`}
         >
           Save

--- a/src/pages/Recipe/Create/index.js
+++ b/src/pages/Recipe/Create/index.js
@@ -1,5 +1,4 @@
 import { useAuth } from 'context/AuthContext'
-import { useAlert, alertType } from 'context/AlertContext'
 import Form from 'components/Recipe/Form'
 import { useHistory, useLocation, Redirect } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
@@ -12,7 +11,6 @@ export default function CreateRecipe() {
   const history = useHistory()
   const location = useLocation()
   const { isAuthenticated } = useAuth()
-  const { addAlert } = useAlert()
 
   const methods = useForm({
     resolver: yupResolver(schema),
@@ -44,11 +42,10 @@ export default function CreateRecipe() {
 
     const { error } = await insertRecipe({ object })
 
-    if (error) {
-      addAlert({
-        type: alertType.ERROR,
-        header: error.message,
-        close: true,
+    if (error?.message.includes('Uniqueness violation')) {
+      methods.setError('name', {
+        message: 'Recipe name must be unique',
+        shouldFocus: true,
       })
     } else {
       history.push(`/recipe`, { createdRecipe: true })


### PR DESCRIPTION
# Implementation
- used `setError` in `react-hook-form` to implement error messaging that is same as form error handling; gets validated after submission &mdash; [reference](https://react-hook-form.com/api#setError)
- using unique constraint from graphql, a user cannot create a repeated recipe name for themselves but other users can use the same name