### PR TITLE
fix recipe create cache

### DIFF
--- a/src/cache/Updates.js
+++ b/src/cache/Updates.js
@@ -94,11 +94,13 @@ export const updates = {
           // `unshift` adds to top of recipe results
           // [NEW BUG] Issue also happens when you log in on clicking 'Create Recipe'
           //  as logging in clears cache
-          data.recipe.unshift(result.insert_recipe_one)
-          if (data.recipe.length > 10) {
-            data.recipe.pop()
+          if (data) {
+            data.recipe.unshift(result.insert_recipe_one)
+            if (data.recipe.length > 10) {
+              data.recipe.pop()
+            }
+            data.recipe_aggregate.aggregate.count++
           }
-          data.recipe_aggregate.aggregate.count++
           return data
         }
       )


### PR DESCRIPTION
# Bug & Fix
- if user enter from `/recipe?page=3` and creates a recipe it will error out because it will write to cache for the query for `/recipe?page=1` but the user never been to that page
- Fix &mdash; ignore writing to that query if it doesn't exist