### PR TITLE
Add pagination to brew log's recipe search

### DIFF
--- a/src/pages/BrewLog/Create/BrewLogForm.js
+++ b/src/pages/BrewLog/Create/BrewLogForm.js
@@ -5,6 +5,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { INSERT_BREW_LOG_ONE } from 'queries'
 import { schema } from 'components/BrewLog/Schema'
 import { Form, Header, Title } from 'components/BrewLog/Form'
+import { setUrqlHeader } from 'helper/header'
 
 export default function BrewLogForm({ goBack, payload }) {
   const history = useHistory()
@@ -20,7 +21,10 @@ export default function BrewLogForm({ goBack, payload }) {
       object.template_recipe_id = payload.templateRecipeId
     }
 
-    const { data, error } = await insertBrewLog({ object })
+    const { data, error } = await insertBrewLog(
+      { object },
+      setUrqlHeader({ 'x-hasura-role': 'all_barista' })
+    )
 
     if (error?.message.includes('Uniqueness violation')) {
       methods.setError('title', {
@@ -30,6 +34,7 @@ export default function BrewLogForm({ goBack, payload }) {
     } else {
       history.push(`/brewlog/${data.insert_brew_log_one.id}`, {
         createdBrewLog: true,
+        id: data.insert_brew_log_one.id,
       })
     }
   }

--- a/src/pages/BrewLog/Edit/BrewLogEdit.js
+++ b/src/pages/BrewLog/Edit/BrewLogEdit.js
@@ -6,6 +6,7 @@ import { useMutation } from 'urql'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useForm } from 'react-hook-form'
 import { schema } from 'components/BrewLog/Schema'
+import { setUrqlHeader } from 'helper/header'
 
 export default function BrewLogEdit({ goBack, store, payload }) {
   const { addAlert } = useAlert()
@@ -32,13 +33,7 @@ export default function BrewLogEdit({ goBack, store, payload }) {
           id,
           brew_log,
         },
-        {
-          fetchOptions: {
-            headers: {
-              'x-hasura-role': 'all_barista',
-            },
-          },
-        }
+        setUrqlHeader({ 'x-hasura-role': 'all_barista' })
       )
       if (error) {
         if (error.message.includes('Uniqueness violation')) {

--- a/src/pages/BrewLog/Main/Routes.js
+++ b/src/pages/BrewLog/Main/Routes.js
@@ -15,20 +15,20 @@ import Welcome from './Welcome'
 
 export default function Routes({ fetching }) {
   const { path } = useRouteMatch()
-  const location = useLocation()
+  const { state } = useLocation()
   const history = useHistory()
   const { addAlert } = useAlert()
 
   useEffect(() => {
-    if (location.state?.createdBrewLog) {
+    if (state?.createdBrewLog) {
       addAlert({
         type: alertType.SUCCESS,
         header: 'Brew log successfully created!',
         close: true,
       })
-      history.replace(path, {})
+      history.replace(path + '/' + state.id, {})
     }
-  }, [addAlert, location, history, path])
+  }, [addAlert, state, history, path])
 
   if (fetching) return <Loading defaultPadding={false} containerClass='p-4' />
 

--- a/src/pages/Recipe/Recipe/index.js
+++ b/src/pages/Recipe/Recipe/index.js
@@ -9,6 +9,7 @@ import { useModal } from 'context/ModalContext'
 import Table from './Table'
 import { range } from 'helper/array'
 import { Pagination } from 'components/Utility/List'
+import { setUrqlHeader } from 'helper/header'
 
 const Recipes = () => {
   const { isAuthenticated, isVerified } = useAuth()
@@ -35,13 +36,7 @@ const Recipes = () => {
         page === undefined || page === '1' ? 0 : (parseInt(page) - 1) * 10,
     },
     context: useMemo(
-      () => ({
-        fetchOptions: {
-          headers: {
-            'x-hasura-role': 'all_barista',
-          },
-        },
-      }),
+      () => setUrqlHeader({ 'x-hasura-role': 'all_barista' }),
       []
     ),
   })


### PR DESCRIPTION
#243

# Changes
- Discovered bug with inserting brew log with another user's recipe via import (got `null` for `barista`). &mdash; **resolved in** https://github.com/brewbean/graphql/pull/24
  - In client, add `all_barista` to `insertBrewLog` header
- Added pagination for `src/pages/BrewLog/Create/Search.js` to allow users to go through recipes
  - **future enhancement** could be to add a search bar or ability to jump to certain pages, right now this is a simple implementation for the size of recipes we have