### PR TITLE
Fix back button bug in brew log create

### DIFF
--- a/src/components/Form/Navigation/index.js
+++ b/src/components/Form/Navigation/index.js
@@ -4,7 +4,7 @@ export default function FormNavigation({
   routes,
   defaultPath,
   defaultPayload = null,
-  initialStore = null,
+  initialStore = {},
 }) {
   const [store, setStore] = useState(initialStore)
   const [view, setView] = useState({

--- a/src/pages/BrewLog/Create/BrewLogForm.js
+++ b/src/pages/BrewLog/Create/BrewLogForm.js
@@ -7,16 +7,17 @@ import { schema } from 'components/BrewLog/Schema'
 import { Form, Header, Title } from 'components/BrewLog/Form'
 import { setUrqlHeader } from 'helper/header'
 
-export default function BrewLogForm({ goBack, payload }) {
+export default function BrewLogForm({ goBack, payload, store, setStore }) {
   const history = useHistory()
   const methods = useForm({
     resolver: yupResolver(schema),
+    defaultValues: store.brewLog ? store.brewLog : {},
   })
 
   const [, insertBrewLog] = useMutation(INSERT_BREW_LOG_ONE)
 
   const submitBrewLog = async (object) => {
-    object.recipe_id = payload.recipe.id
+    object.recipe_id = payload.recipeId
     if (payload.templateRecipeId) {
       object.template_recipe_id = payload.templateRecipeId
     }
@@ -39,17 +40,22 @@ export default function BrewLogForm({ goBack, payload }) {
     }
   }
 
+  const goBackWithSave = () => {
+    setStore({ ...store, brewLog: methods.getValues() })
+    goBack()
+  }
+
   return (
     <>
-      <Header goBack={goBack} />
+      <Header goBack={goBackWithSave} />
       <Title
         extraClasses='mb-4 mt-2 sm:mb-0'
         title='Create a brew log'
-        subtitle={payload.subtitle}
+        subtitle='Add brew log details'
       />
       <Form
         {...methods}
-        onCancel={goBack}
+        onCancel={goBackWithSave}
         onSubmit={methods.handleSubmit(submitBrewLog)}
       />
     </>

--- a/src/pages/BrewLog/Create/Edit.js
+++ b/src/pages/BrewLog/Create/Edit.js
@@ -1,0 +1,91 @@
+import { useMutation } from 'urql'
+import { useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { UPDATE_RECIPE_WITH_STAGES } from 'queries'
+import Form from 'components/Recipe/Form'
+import { Header, Title } from 'components/BrewLog/Form'
+import { schema } from 'components/Recipe/Schema'
+import { addServeToStages } from 'helper/recipe'
+import { BREWLOG_FORM } from 'pages/BrewLog/Create'
+import { getDefaultValues } from 'components/Utility/Form'
+import { alertType, useAlert } from 'context/AlertContext'
+
+export default function Edit({ goBack, goTo, store, setStore, payload }) {
+  const { addAlert } = useAlert()
+  const [, updateRecipe] = useMutation(UPDATE_RECIPE_WITH_STAGES)
+
+  const defaultValues = getDefaultValues(store.recipe)
+  const methods = useForm({
+    resolver: yupResolver(schema),
+    defaultValues,
+  })
+
+  const { isDirty } = methods.formState
+
+  const submitRecipe = async ({ stages, serve, ...recipe }) => {
+    const { id } = store.recipe
+
+    if (isDirty) {
+      const newStages = stages
+        ? addServeToStages(stages, serve).map((s) => ({
+            ...s,
+            recipe_id: id,
+          }))
+        : [] // change 'null' to empty array to add no new stages; old stages get deleted regardless
+
+      let { data, error } = await updateRecipe({
+        id,
+        recipe,
+        stages: newStages,
+      })
+
+      if (error) {
+        if (error.message.includes('Uniqueness violation')) {
+          methods.setError('name', {
+            message: 'This recipe name already exist',
+            shouldFocus: true,
+          })
+        } else {
+          addAlert({
+            type: alertType.ERROR,
+            header: error.message,
+            close: true,
+          })
+        }
+        return
+      } else {
+        // in case user wants to go back to edit recipe
+        //  using ...store in case we want to preserve other store variables such as 'createdTemplateRecipe'
+        setStore({ ...store, recipe: data.update_recipe_by_pk })
+      }
+    }
+
+    let brewlogPayload = { recipeId: id }
+    if (store.createdTemplateRecipe) {
+      brewlogPayload.templateRecipeId = payload.id
+    }
+    goTo(BREWLOG_FORM, brewlogPayload)
+  }
+
+  // clear store since going back from edit means you've started from scratch
+  const goBackClear = () => {
+    setStore({})
+    goBack()
+  }
+
+  return (
+    <>
+      <Header goBack={goBackClear} />
+      <Title
+        extraClasses='mt-2'
+        title='Create a brew log'
+        subtitle='Create a recipe'
+      />
+      <Form
+        {...methods}
+        onCancel={goBackClear}
+        onSubmit={methods.handleSubmit(submitRecipe)}
+      />
+    </>
+  )
+}

--- a/src/pages/BrewLog/Create/Introduction.js
+++ b/src/pages/BrewLog/Create/Introduction.js
@@ -9,7 +9,7 @@ export default function Introduction({ goTo }) {
       <Title
         extraClasses='border-none'
         title='Create a brew log'
-        subtitle='Step 1: Add a recipe'
+        subtitle='Add a recipe'
       />
 
       <div className='mt-6 flex flex-col space-y-2 sm:flex-row sm:space-y-0 items-center justify-center'>

--- a/src/pages/BrewLog/Create/RecipeForm/Create.js
+++ b/src/pages/BrewLog/Create/RecipeForm/Create.js
@@ -5,19 +5,14 @@ import { INSERT_RECIPES_ONE } from 'queries'
 import Form from 'components/Recipe/Form'
 import { Header, Title } from 'components/BrewLog/Form'
 import { schema } from 'components/Recipe/Schema'
-import { getDefaultValues } from 'components/Utility/Form'
 import { addServeToStages } from 'helper/recipe'
 import { BREWLOG_FORM } from 'pages/BrewLog/Create'
 
-export default function TemplateForm({ goBack, goTo, payload }) {
+export default function Create({ goBack, goTo, setStore }) {
   const [, insertRecipe] = useMutation(INSERT_RECIPES_ONE)
-  const defaultValues = getDefaultValues(payload, [
-    { key: 'name', value: undefined },
-    { key: 'is_private', value: true },
-  ])
   const methods = useForm({
     resolver: yupResolver(schema),
-    defaultValues,
+    defaultValues: { is_private: true },
   })
 
   const submitRecipe = async ({ stages, serve, ...recipe }) => {
@@ -37,10 +32,10 @@ export default function TemplateForm({ goBack, goTo, payload }) {
         shouldFocus: true,
       })
     } else {
+      // in case user wants to go back to edit recipe
+      setStore({ recipe: data.insert_recipe_one, createdRecipeScratch: true })
       goTo(BREWLOG_FORM, {
-        recipe: data.insert_recipe_one,
-        templateRecipeId: payload.id,
-        subtitle: 'Step 4: Add brew log details',
+        recipeId: data.insert_recipe_one.id,
       })
     }
   }
@@ -51,20 +46,12 @@ export default function TemplateForm({ goBack, goTo, payload }) {
       <Title
         extraClasses='mt-2'
         title='Create a brew log'
-        subtitle='Step 3: Modify your template base'
+        subtitle='Step 2: Create a recipe'
       />
       <Form
         {...methods}
         onCancel={goBack}
         onSubmit={methods.handleSubmit(submitRecipe)}
-        preload={
-          defaultValues.serve !== 0 && {
-            formMounted: true,
-            isHidden: true,
-            stages: defaultValues.stages,
-            serveTime: defaultValues.serve,
-          }
-        }
       />
     </>
   )

--- a/src/pages/BrewLog/Create/RecipeForm/index.js
+++ b/src/pages/BrewLog/Create/RecipeForm/index.js
@@ -1,0 +1,10 @@
+import Edit from 'pages/BrewLog/Create/Edit'
+import Create from './Create'
+
+export default function RecipeForm(props) {
+  return props.store.createdRecipeScratch ? (
+    <Edit {...props} />
+  ) : (
+    <Create {...props} />
+  )
+}

--- a/src/pages/BrewLog/Create/RecipeImport.js
+++ b/src/pages/BrewLog/Create/RecipeImport.js
@@ -2,11 +2,7 @@ import { Header, RecipeSection, Title } from 'components/BrewLog/Form'
 import { BREWLOG_FORM } from 'pages/BrewLog/Create'
 
 export default function RecipeImport({ goBack, goTo, payload }) {
-  const goToBrewLogForm = () =>
-    goTo(BREWLOG_FORM, {
-      recipe: payload,
-      subtitle: 'Step 4: Add brew log details',
-    })
+  const goToBrewLogForm = () => goTo(BREWLOG_FORM, { recipeId: payload.id })
 
   return (
     <>
@@ -14,7 +10,7 @@ export default function RecipeImport({ goBack, goTo, payload }) {
       <Title
         extraClasses='mt-2'
         title='Create a brew log'
-        subtitle='Step 3: Confirm recipe import'
+        subtitle='Confirm recipe import'
       />
       <dl className='mt-4 grid grid-cols-1 gap-6 lg:grid-cols-2'>
         <RecipeSection {...payload} />

--- a/src/pages/BrewLog/Create/Search.js
+++ b/src/pages/BrewLog/Create/Search.js
@@ -110,7 +110,7 @@ export default function Search({ goBack, goTo }) {
       <Title
         extraClasses='mt-2'
         title='Create a brew log'
-        subtitle='Step 2: Select a recipe to import or use as a template!'
+        subtitle='Select a recipe to import or use as a template'
       />
 
       <ul className='mt-4'>

--- a/src/pages/BrewLog/Create/TemplateForm/Create.js
+++ b/src/pages/BrewLog/Create/TemplateForm/Create.js
@@ -5,14 +5,19 @@ import { INSERT_RECIPES_ONE } from 'queries'
 import Form from 'components/Recipe/Form'
 import { Header, Title } from 'components/BrewLog/Form'
 import { schema } from 'components/Recipe/Schema'
+import { getDefaultValues } from 'components/Utility/Form'
 import { addServeToStages } from 'helper/recipe'
 import { BREWLOG_FORM } from 'pages/BrewLog/Create'
 
-export default function RecipeForm({ goBack, goTo }) {
+export default function Create({ goBack, goTo, payload, setStore }) {
   const [, insertRecipe] = useMutation(INSERT_RECIPES_ONE)
+  const defaultValues = getDefaultValues(payload, [
+    { key: 'name', value: undefined },
+    { key: 'is_private', value: true },
+  ])
   const methods = useForm({
     resolver: yupResolver(schema),
-    defaultValues: { is_private: true },
+    defaultValues,
   })
 
   const submitRecipe = async ({ stages, serve, ...recipe }) => {
@@ -32,9 +37,10 @@ export default function RecipeForm({ goBack, goTo }) {
         shouldFocus: true,
       })
     } else {
+      setStore({ recipe: data.insert_recipe_one, createdTemplateRecipe: true }) // in case user wants to go back to edit recipe
       goTo(BREWLOG_FORM, {
-        recipe: data.insert_recipe_one,
-        subtitle: 'Step 3: Add brew log details',
+        recipeId: data.insert_recipe_one.id,
+        templateRecipeId: payload.id,
       })
     }
   }
@@ -45,12 +51,20 @@ export default function RecipeForm({ goBack, goTo }) {
       <Title
         extraClasses='mt-2'
         title='Create a brew log'
-        subtitle='Step 2: Create a recipe'
+        subtitle='Step 3: Modify your template base'
       />
       <Form
         {...methods}
         onCancel={goBack}
         onSubmit={methods.handleSubmit(submitRecipe)}
+        preload={
+          defaultValues.serve !== 0 && {
+            formMounted: true,
+            isHidden: true,
+            stages: defaultValues.stages,
+            serveTime: defaultValues.serve,
+          }
+        }
       />
     </>
   )

--- a/src/pages/BrewLog/Create/TemplateForm/index.js
+++ b/src/pages/BrewLog/Create/TemplateForm/index.js
@@ -1,0 +1,10 @@
+import Edit from 'pages/BrewLog/Create/Edit'
+import Create from './Create'
+
+export default function TemplateForm(props) {
+  return props.store.createdTemplateRecipe ? (
+    <Edit {...props} />
+  ) : (
+    <Create {...props} />
+  )
+}


### PR DESCRIPTION
#244

# Changes
- Utilize `store` in `FormNavigation` to create saved states in form
- Navigating back after creating a recipe will now allow you to edit that recipe &mdash; create now has editing capabilities
- brew log also saves **_draft_** when you navigate back and forth &mdash; meaning your incomplete brew log entries will stay until you go all the way back or submit