### PR TITLE
Safari bug fix

### DIFF
--- a/src/components/BrewLog/Sidebar/index.js
+++ b/src/components/BrewLog/Sidebar/index.js
@@ -36,7 +36,7 @@ const LinkButton = ({ id, title, date_created, rating }) => {
 
 const Sidebar = ({ loading, error, logs }) =>
   loading || !logs ? (
-    <Loading defaultPadding={false} containerClass='p-4 bg-gray-50' />
+    <Loading defaultPadding={false} containerClass='p-4' />
   ) : error ? (
     <div className='p-4 bg-gray-50 text-red-600 flex flex-col items-center'>
       <Error className='h-6 w-6' />

--- a/src/components/Stage/index.js
+++ b/src/components/Stage/index.js
@@ -32,11 +32,7 @@ export const StageSection = ({ stages, playerPath }) =>
         <Table stages={stages} />
       </div>
       {playerPath && (
-        <Link
-          to={playerPath}
-          type='button'
-          className='w-full btn btn--primary btn--md'
-        >
+        <Link to={playerPath} className='w-full btn btn--primary btn--md'>
           Go to Recipe Player
         </Link>
       )}

--- a/src/pages/BrewLog/Main/Routes.js
+++ b/src/pages/BrewLog/Main/Routes.js
@@ -30,6 +30,10 @@ export default function Routes({ fetching }) {
     }
   }, [addAlert, state, history, path])
 
+  /**
+   * Simplistic way to wait for sidebar to fetch all brew logs
+   * - result: detail page will likely be fetched from cache (if on same page; common case unless from link)
+   */
   if (fetching) return <Loading defaultPadding={false} containerClass='p-4' />
 
   return (

--- a/src/pages/BrewLog/Main/index.js
+++ b/src/pages/BrewLog/Main/index.js
@@ -23,8 +23,8 @@ export default function Main({ fetching, error, data, goToCreate }) {
         <div className='min-h-0 flex-1 flex overflow-hidden'>
           <main className='min-w-0 flex-1 flex space-x-4'>
             {/* brew log list*/}
-            <aside className='flex-shrink-0'>
-              <div className='h-full flex flex-col w-80 bg-gray-50 rounded-lg'>
+            <aside className='flex flex-shrink-0'>
+              <div className='flex flex-col w-80 bg-gray-50 rounded-lg'>
                 <div className='flex-shrink-0 h-16 px-6 flex justify-between items-center border-b border-gray-200'>
                   <Link
                     to={url}
@@ -64,7 +64,7 @@ export default function Main({ fetching, error, data, goToCreate }) {
             </aside>
 
             {/* Detail area */}
-            <section className='min-w-0 flex-1 h-full flex flex-col overflow-hidden bg-white rounded-lg'>
+            <section className='min-w-0 flex-1 flex flex-col overflow-hidden bg-white rounded-lg'>
               <div className='min-h-0 flex-1 overflow-y-auto'>
                 {/* Content */}
                 <div className='px-4 py-5 sm:px-6'>

--- a/src/pages/Recipe/Detail/index.js
+++ b/src/pages/Recipe/Detail/index.js
@@ -13,6 +13,7 @@ import { DescriptionSection } from 'components/Layout/Detail'
 import { ModifyRow } from 'components/Form/ButtonGroup'
 import { useModal } from 'context/ModalContext'
 import { placeholder } from 'image'
+import { setUrqlHeader } from 'helper/header'
 
 const Detail = () => {
   const history = useHistory()
@@ -43,13 +44,7 @@ const Detail = () => {
     query: GET_SINGLE_RECIPE_REVIEWS_AVG_REVIEW,
     variables: { id: parseInt(id) },
     context: useMemo(
-      () => ({
-        fetchOptions: {
-          headers: {
-            'x-hasura-role': 'all_barista',
-          },
-        },
-      }),
+      () => setUrqlHeader({ 'x-hasura-role': 'all_barista' }),
       []
     ),
   })


### PR DESCRIPTION
Addresses #254 

# Changes
- Removed `bg-gray-50` background from a loading spinner on `<Sidebar />` **&mdash; not a safari bug**
- Fixed weird styling of link on recipe page for recipe player **&mdash; bug: had a `type='button'` on a link (safari doesn't like this)**
- Fixed broken pagination area on brew log along with main content not being fully scrollable
  - Safari doesn't use `h-full` (`height: 100%`) for giving full height to a flex child. Was able to replace with `flex` or just remove **&mdash; confirmed that it works the same on chrome**