### PR TITLE
Fix unverified modal from side effects & improve 429 error

### DIFF
--- a/src/context/AlertContext.js
+++ b/src/context/AlertContext.js
@@ -16,9 +16,7 @@ const AlertProvider = ({ children }) => {
   const location = useLocation()
 
   useEffect(() => {
-    if (!location.state) {
-      setAlerts([])
-    }
+    setAlerts([])
   }, [location])
 
   const clearAlerts = useCallback(() => setAlerts([]), [])
@@ -26,20 +24,18 @@ const AlertProvider = ({ children }) => {
   // destructured for clarity - can remove if we implement TypeScript types/interfaces
   // useCallback used here to provide stable reference
   // as 'addAlert' is in the dependency graph of a useEffect block
-  const addAlert = useCallback(
-    (alert) =>
-      setAlerts((prevAlerts) => [
-        ...prevAlerts,
-        {
-          type: alert.type,
-          header: alert.header,
-          message: alert.message,
-          close: alert.close,
-          action: alert.action,
-        },
-      ]),
-    []
-  )
+  const addAlert = useCallback((alert) => {
+    setAlerts((prevAlerts) => [
+      ...prevAlerts,
+      {
+        type: alert.type,
+        header: alert.header,
+        message: alert.message,
+        close: alert.close,
+        action: alert.action,
+      },
+    ])
+  }, [])
 
   const addAlertBulk = (bulk) => setAlerts([...alerts, ...bulk])
 

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -184,8 +184,11 @@ function AuthProvider({ children }) {
           } else {
             const barista = data.data.barista[0]
             dispatch(['setBarista', barista])
-
-            if (!barista.is_verified && location.pathname !== '/profile') {
+            if (
+              !barista.is_verified &&
+              location.pathname !== '/profile' &&
+              location.pathname !== '/create-account'
+            ) {
               addAlert(createUnverifiedAlert(barista.email))
             }
           }
@@ -259,6 +262,12 @@ function AuthProvider({ children }) {
           header: err.message,
           message: 'Our servers or your internet may be down at this time.',
         })
+      } else if (err.response.status === 429) {
+        addAlert({
+          type: alertType.ERROR,
+          header: err.response.statusText,
+          message: 'Try again in an hour.',
+        })
       } else {
         addAlert({
           type: alertType.ERROR,
@@ -313,7 +322,10 @@ function AuthProvider({ children }) {
     return null
   }
 
-  const closeIntroModal = () => dispatch(['setIsIntroModalOpen', false])
+  const closeIntroModal = () => {
+    addAlert(createUnverifiedAlert(state.barista.email))
+    dispatch(['setIsIntroModalOpen', false])
+  }
 
   return (
     <AuthContext.Provider


### PR DESCRIPTION
**addresses #159**

# Notes
- Bug was no longer present probably due to earlier refactor on the login flow after signing up in `AuthContext`
- However, there was a alert being triggered that was being wiped away by the time it got to the `/` page which meant that it was supposed to work, but there was a race condition on the clearing

# Changes
- To address the issue, I changed the clear for alerts to be based on `location` changes period, not sure why, but previously this was only changing if `!location.state` which probably is why going back and forth seemed to preserve alerts (**_maybe_**)
- This still didn't fix it because the `addAlert` was called early on `/create-account` path so by the time we got to `/`, it cleared
- I tried different fixes but they ran into a race condition with the `useEffect` for clearing alerts. The cleanest solution turned out to be to trigger the `addAlert` when you close the intro modal (**_very simple_**)
- Unrelated change - noticed how 429 errors were being rendered (too many login attempts) and fixed the alert rendering which was blank because our rate limit error signature is different from our normal errors (in regards to message)