### PR TITLE
Add visibility marker to recipe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@cloudinary/base": "^1.0.0-beta.0",
         "@craco/craco": "^6.1.1",
-        "@headlessui/react": "^0.2.0",
+        "@headlessui/react": "^1.0.0",
+        "@heroicons/react": "^1.0.1",
         "@hookform/resolvers": "^1.3.5",
         "@tailwindcss/aspect-ratio": "^0.2.0",
         "@tailwindcss/forms": "^0.2.1",
@@ -1385,11 +1386,22 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-0.2.0.tgz",
-      "integrity": "sha512-YV+vF+QhTRcspydPdHF3ZXe+FkOiJpRdqMjjFIIX9bSdT2O2T7GurgKQdGgamNUM+B99MZBOTRqxS8Dlh485eg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.0.0.tgz",
+      "integrity": "sha512-mjqRJrgkbcHQBfAHnqH0yRxO/y/22jYrdltpE7WkurafREKZ+pj5bPBwYHMt935Sdz/n16yRcVmsSCqDFHee9A==",
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.1.tgz",
+      "integrity": "sha512-uikw2gKCmqnvjVxitecWfFLMOKyL9BTFcU4VM3hHj9OMwpkCr5Ke+MRMyY2/aQVmsYs4VTq7NCFX05MYwAHi3g==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -20604,9 +20616,9 @@
       }
     },
     "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -22449,9 +22461,16 @@
       }
     },
     "@headlessui/react": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-0.2.0.tgz",
-      "integrity": "sha512-YV+vF+QhTRcspydPdHF3ZXe+FkOiJpRdqMjjFIIX9bSdT2O2T7GurgKQdGgamNUM+B99MZBOTRqxS8Dlh485eg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.0.0.tgz",
+      "integrity": "sha512-mjqRJrgkbcHQBfAHnqH0yRxO/y/22jYrdltpE7WkurafREKZ+pj5bPBwYHMt935Sdz/n16yRcVmsSCqDFHee9A==",
+      "requires": {}
+    },
+    "@heroicons/react": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.1.tgz",
+      "integrity": "sha512-uikw2gKCmqnvjVxitecWfFLMOKyL9BTFcU4VM3hHj9OMwpkCr5Ke+MRMyY2/aQVmsYs4VTq7NCFX05MYwAHi3g==",
+      "requires": {}
     },
     "@hookform/resolvers": {
       "version": "1.3.5",
@@ -37839,9 +37858,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@cloudinary/base": "^1.0.0-beta.0",
     "@craco/craco": "^6.1.1",
-    "@headlessui/react": "^0.2.0",
+    "@headlessui/react": "^1.0.0",
+    "@heroicons/react": "^1.0.1",
     "@hookform/resolvers": "^1.3.5",
     "@tailwindcss/aspect-ratio": "^0.2.0",
     "@tailwindcss/forms": "^0.2.1",

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -13,3 +13,13 @@ export const Rating = ({ value }) => (
     {value ? value : 'not rated'}
   </span>
 )
+
+export const TextSymbol = ({ symbol, children }) => {
+  const Symbol = symbol
+  return (
+    <span className='badge badge--indigo'>
+      {children}
+      <Symbol className='h-3 w-3 ml-1' />
+    </span>
+  )
+}

--- a/src/components/BrewLog/Detail/index.js
+++ b/src/components/BrewLog/Detail/index.js
@@ -1,6 +1,6 @@
 import { Link, useRouteMatch } from 'react-router-dom'
 import { Rating } from 'components/Badge'
-import { Eye, EyeOff } from 'components/Icon'
+import { PrivacyIcon } from 'components/Icon'
 import { DataSection } from 'components/Layout/Detail'
 import { StageSection } from 'components/Stage'
 import { combineClass } from 'helper/stringHelper'
@@ -27,19 +27,15 @@ export const Description = ({
       </div>
 
       <dl className='mt-6 grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2'>
-        <DataSection className='sm:col-span-1' label='Log Private'>
+        <DataSection className='sm:col-span-1' label='Privacy'>
           <span
             className={combineClass('badge', {
               'badge--gray': is_private,
               'badge--indigo': !is_private,
             })}
           >
-            {is_private.toString()}
-            {is_private ? (
-              <EyeOff className='h-3 w-3 ml-1' />
-            ) : (
-              <Eye className='h-3 w-3 ml-1' />
-            )}
+            {is_private ? 'Private' : 'Public'}
+            <PrivacyIcon isPrivate={is_private} className='h-3 w-3 ml-1' />
           </span>
         </DataSection>
         <DataSection className='sm:col-span-1' label='Rating'>

--- a/src/components/FormAlert/index.js
+++ b/src/components/FormAlert/index.js
@@ -1,9 +1,9 @@
-import { ExclamationCircle } from 'components/Icon'
+import { ExclamationCircleIcon } from '@heroicons/react/solid'
 import { alertType } from 'context/AlertContext'
 
 const Warning = ({ text }) => (
   <div className='flex items-center'>
-    <ExclamationCircle className='text-yellow-500 h-5 w-5' />
+    <ExclamationCircleIcon className='text-yellow-500 h-5 w-5' />
     <span className='ml-1 text-sm text-gray-700'>{text}</span>
   </div>
 )

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,5 +1,13 @@
+import { EyeIcon, EyeOffIcon } from '@heroicons/react/solid'
 import * as Alert from './Alert'
 export { Alert }
+
+export const PrivacyIcon = ({ isPrivate, className }) =>
+  isPrivate ? (
+    <EyeOffIcon className={className} />
+  ) : (
+    <EyeIcon className={className} />
+  )
 
 export const Download = ({ className = 'h-6 w-6' }) => (
   <svg
@@ -239,21 +247,6 @@ export const XCircle = ({ className = 'w-6 h-6' }) => (
     <path
       fillRule='evenodd'
       d='M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z'
-      clipRule='evenodd'
-    />
-  </svg>
-)
-
-export const ExclamationCircle = ({ className = 'w-6 h-6' }) => (
-  <svg
-    className={className}
-    fill='currentColor'
-    viewBox='0 0 20 20'
-    xmlns='http://www.w3.org/2000/svg'
-  >
-    <path
-      fillRule='evenodd'
-      d='M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z'
       clipRule='evenodd'
     />
   </svg>

--- a/src/components/Recipe/Detail/index.js
+++ b/src/components/Recipe/Detail/index.js
@@ -4,6 +4,8 @@ import { StageSection } from 'components/Stage'
 import { Rating } from 'components/Badge'
 import { All, Create, Edit } from 'components/Recipe/Review'
 import { DataSection } from 'components/Layout/Detail'
+import { combineClass } from 'helper/stringHelper'
+import { PrivacyIcon } from 'components/Icon'
 
 export const Description = ({
   brew_type,
@@ -99,15 +101,38 @@ export const CommentSection = ({ recipeId, recipeReviews, canReview }) => {
   )
 }
 
-export const TitleSection = ({ img, dateAdded, name, recipeName }) => (
+export const TitleSection = ({
+  img,
+  dateAdded,
+  name,
+  recipeName,
+  showPrivacyBadge,
+  isPrivate,
+}) => (
   <div className='flex items-center space-x-5'>
     <img className='h-16 w-16 rounded-lg shadow' src={img.src} alt={img.alt} />
     <div>
       <h1 className='text-2xl font-bold text-gray-900'>{recipeName}</h1>
-      <p className='text-sm font-medium text-gray-500'>
-        Created by {name} on{' '}
-        <time dateTime={dateAdded}>{dateAdded.substring(0, 10)}</time>
-      </p>
+      <div className='flex flex-col sm:flex-row'>
+        <p className='text-sm font-medium text-gray-500'>
+          Created by {name} on{' '}
+          <time dateTime={dateAdded}>{dateAdded.substring(0, 10)}</time>
+        </p>
+
+        {showPrivacyBadge && (
+          <div className='mt-1 sm:mt-0'>
+            <span
+              className={combineClass('sm:ml-2 badge', {
+                'badge--gray': isPrivate,
+                'badge--indigo': !isPrivate,
+              })}
+            >
+              {isPrivate ? 'Private' : 'Public'}
+              <PrivacyIcon isPrivate={isPrivate} className='h-3 w-3 ml-1' />
+            </span>
+          </div>
+        )}
+      </div>
     </div>
   </div>
 )

--- a/src/components/Utility/ErrorMessage.js
+++ b/src/components/Utility/ErrorMessage.js
@@ -1,0 +1,9 @@
+import { ExclamationCircleIcon } from '@heroicons/react/solid'
+
+const ErrorMessage = ({ message }) => (
+  <div className='text-red-600 flex flex-col items-center'>
+    <ExclamationCircleIcon className='w-6 h-6' />
+    <h1 className='mt-2 text-sm font-medium'>{message}</h1>
+  </div>
+)
+export default ErrorMessage

--- a/src/components/Utility/index.js
+++ b/src/components/Utility/index.js
@@ -1,5 +1,6 @@
 import Loading from './Loading'
 import Unauthorized from './Unauthorized'
 import ButtonLoading from './ButtonLoading'
+import ErrorMessage from './ErrorMessage'
 
-export { Loading, Unauthorized, ButtonLoading }
+export { Loading, Unauthorized, ButtonLoading, ErrorMessage }

--- a/src/pages/BrewLog/Create/Search.js
+++ b/src/pages/BrewLog/Create/Search.js
@@ -4,8 +4,7 @@ import { GET_ALL_RECIPES } from 'queries'
 import { Header, Title } from 'components/BrewLog/Form'
 import { TEMPLATE_FORM, RECIPE_IMPORT } from './index'
 import { setUrqlHeader } from 'helper/header'
-import { Loading } from 'components/Utility'
-import { ExclamationCircle } from 'components/Icon'
+import { ErrorMessage, Loading } from 'components/Utility'
 import { combineClass } from 'helper/stringHelper'
 
 const RecipeRow = ({ onImport, onTemplate, recipeName, displayName }) => (
@@ -28,13 +27,6 @@ const RecipeRow = ({ onImport, onTemplate, recipeName, displayName }) => (
       </button>
     </div>
   </li>
-)
-
-const ErrorMessage = ({ message }) => (
-  <div className='text-red-600 flex flex-col items-center'>
-    <ExclamationCircle />
-    <h1 className='mt-2 text-sm font-medium'>{message}</h1>
-  </div>
 )
 
 const PaginationRow = ({

--- a/src/pages/BrewLog/Detail/index.js
+++ b/src/pages/BrewLog/Detail/index.js
@@ -6,7 +6,7 @@ import { Error } from 'components/Icon/Alert'
 import { Loading } from 'components/Utility'
 import { Description } from 'components/BrewLog/Detail'
 import { useModal } from 'context/ModalContext'
-import { ExclamationCircle } from 'components/Icon'
+import { ExclamationCircleIcon } from '@heroicons/react/solid'
 
 export default function Detail() {
   const history = useHistory()
@@ -53,7 +53,7 @@ export default function Detail() {
     </div>
   ) : !data ? (
     <div className='text-gray-700 flex flex-col items-center col-span-2'>
-      <ExclamationCircle />
+      <ExclamationCircleIcon className='w-6 h-6' />
       <h1 className='mt-2 text-sm font-medium'>No brew log here!</h1>
     </div>
   ) : error ? (

--- a/src/pages/Recipe/Detail/index.js
+++ b/src/pages/Recipe/Detail/index.js
@@ -58,6 +58,7 @@ const Detail = () => {
     date_added,
     recipe_reviews,
     stages,
+    is_private,
   } = data.recipe_by_pk
 
   return (
@@ -65,9 +66,11 @@ const Detail = () => {
       {/*<!-- Page header -->*/}
       <div className='md:flex md:items-center md:justify-between md:space-x-5'>
         <TitleSection
-          name={barista?.display_name}
+          name={barista.display_name}
           recipeName={name}
           dateAdded={date_added}
+          isPrivate={is_private}
+          showPrivacyBadge={barista.id === user?.id}
           img={{ src: placeholder.cup, alt: 'coffee cup' }}
         />
         <ModifyRow

--- a/src/pages/Recipe/Recipe/Table.js
+++ b/src/pages/Recipe/Recipe/Table.js
@@ -1,9 +1,12 @@
 import { useHistory, useRouteMatch } from 'react-router-dom'
 import { roundToHalfOrWhole } from 'helper/math'
-import { Check, X } from 'components/Icon'
-import { Rating } from 'components/Badge'
+import { Check, PrivacyIcon, X } from 'components/Icon'
+import { Rating, TextSymbol } from 'components/Badge'
+import { useAuth } from 'context/AuthContext'
+import { UserIcon } from '@heroicons/react/solid'
 
 export default function Table({ recipes }) {
+  const { barista: user } = useAuth()
   const { url } = useRouteMatch()
   const history = useHistory()
 
@@ -53,6 +56,7 @@ export default function Table({ recipes }) {
               name,
               about,
               brew_type,
+              is_private,
               stages,
             }) => (
               <tr
@@ -62,18 +66,34 @@ export default function Table({ recipes }) {
                 onClick={() => history.push(url + '/' + id)}
               >
                 <td className='rounded-l-lg px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900'>
-                  <div>{name}</div>
-                  <div className='text-gray-500 text-xs font-normal'>
-                    {about}
+                  <div className='flex items-center'>
+                    {user?.id === barista.id && (
+                      <PrivacyIcon
+                        isPrivate={is_private}
+                        className='h-5 w-5 mr-3 text-gray-700'
+                      />
+                    )}
+                    <div>
+                      <h1>{name}</h1>
+                      <h2 className='text-gray-500 text-xs font-normal'>
+                        {about}
+                      </h2>
+                    </div>
                   </div>
                 </td>
-                <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-500'>
-                  {barista.display_name}
+                <td className='px-6 py-4 whitespace-nowrap text-xs font-medium text-gray-500'>
+                  {user?.display_name === barista.display_name ? (
+                    <TextSymbol symbol={UserIcon}>
+                      {barista.display_name}
+                    </TextSymbol>
+                  ) : (
+                    barista.display_name
+                  )}
                 </td>
-                <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize'>
+                <td className='px-6 py-4 whitespace-nowrap text-xs font-medium text-gray-500 capitalize'>
                   {brew_type}
                 </td>
-                <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-500'>
+                <td className='px-6 py-4 whitespace-nowrap'>
                   <Rating
                     value={roundToHalfOrWhole(
                       recipe_reviews_aggregate.aggregate.avg.rating

--- a/src/pages/Recipe/Recipe/index.js
+++ b/src/pages/Recipe/Recipe/index.js
@@ -10,6 +10,7 @@ import Table from './Table'
 import { range } from 'helper/array'
 import { Pagination } from 'components/Utility/List'
 import { setUrqlHeader } from 'helper/header'
+import { ErrorMessage, Loading } from 'components/Utility'
 
 const Recipes = () => {
   const { isAuthenticated, isVerified } = useAuth()
@@ -78,8 +79,8 @@ const Recipes = () => {
     }
   }, [isPending, isSuccess, content, isVerified, url, history, reset])
 
-  if (fetching) return <p>Loading...</p>
-  if (error) return <p>Oh no... {error.message}</p>
+  if (fetching) return <Loading />
+  if (error) return <ErrorMessage message={error.message} />
 
   const totalPages = Math.ceil(data.recipe_aggregate.aggregate.count / 10)
   const pageNumbers = totalPages > 1 ? range(1, totalPages) : []


### PR DESCRIPTION
**Addresses #163**

# Changes
- Add @heroicon/react which allows us to use icons without having to add to `src/components/icon` anymore &mdash; _**will slowly remove these icons**_
- Added visibility icons to recipe table and recipe page to show if it is:
  - Your recipe
  - Whether is private or not
  
<img width="1792" alt="Screen Shot 2021-04-14 at 9 14 34 PM" src="https://user-images.githubusercontent.com/6396042/114813674-7381a280-9d67-11eb-8928-d31c9e7a1a31.png">
<img width="1348" alt="Screen Shot 2021-04-14 at 7 33 58 PM" src="https://user-images.githubusercontent.com/6396042/114813679-75e3fc80-9d67-11eb-9079-362fbe8fcde2.png">
