### PR TITLE
Data representation bug fix

### DIFF
--- a/src/components/Bean/Detail/index.js
+++ b/src/components/Bean/Detail/index.js
@@ -16,39 +16,47 @@ export const Description = ({
   about,
   price,
   bean_reviews_aggregate,
-}) => (
-  <>
-    <DataSection className='sm:col-span-1' label='Roast Type'>
-      {wordCapitalized(roast_type)}
-    </DataSection>
-    <DataSection className='sm:col-span-1' label='Profile Notes'>
-      {profile_note}
-    </DataSection>
-    <DataSection className='sm:col-span-1' label='Region'>
-      {region}
-    </DataSection>
-    <DataSection className='sm:col-span-1' label='Altitude'>
-      {altitude ? `${altitude} km` : 'N/A'}
-    </DataSection>
-    <DataSection className='sm:col-span-1' label='Variety'>
-      {varietal ? varietal : 'N/A'}
-    </DataSection>
-    <DataSection className='sm:col-span-1' label='Process'>
-      {process ? process : 'N/A'}
-    </DataSection>
-    <DataSection className='sm:col-span-1' label='Price'>
-      {price ? `${price} USD` : 'N/A'}
-    </DataSection>
-    <DataSection className='sm:col-span-1' label='Rating'>
-      <Rating
-        value={roundToHalfOrWhole(bean_reviews_aggregate.aggregate.avg.rating)}
-      />
-    </DataSection>
-    <DataSection className='sm:col-span-2 whitespace-pre-line' label='About'>
-      {about ? about : 'N/A'}
-    </DataSection>
-  </>
-)
+}) => {
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  })
+  return (
+    <>
+      <DataSection className='sm:col-span-1' label='Roast Type'>
+        {wordCapitalized(roast_type)}
+      </DataSection>
+      <DataSection className='sm:col-span-1' label='Profile Notes'>
+        {profile_note}
+      </DataSection>
+      <DataSection className='sm:col-span-1' label='Region'>
+        {region}
+      </DataSection>
+      <DataSection className='sm:col-span-1' label='Altitude'>
+        {altitude ? `${altitude} km` : 'N/A'}
+      </DataSection>
+      <DataSection className='sm:col-span-1' label='Variety'>
+        {varietal ? varietal : 'N/A'}
+      </DataSection>
+      <DataSection className='sm:col-span-1' label='Process'>
+        {process ? process : 'N/A'}
+      </DataSection>
+      <DataSection className='sm:col-span-1' label='Price'>
+        {price ? `${formatter.format(price)}` : 'N/A'}
+      </DataSection>
+      <DataSection className='sm:col-span-1' label='Rating'>
+        <Rating
+          value={roundToHalfOrWhole(
+            bean_reviews_aggregate.aggregate.avg.rating
+          )}
+        />
+      </DataSection>
+      <DataSection className='sm:col-span-2 whitespace-pre-line' label='About'>
+        {about ? about : 'N/A'}
+      </DataSection>
+    </>
+  )
+}
 
 export const CommentSection = ({ beanId, beanReviews, canReview }) => {
   const [editReview, setEditReview] = useState(null)

--- a/src/components/Bean/Form/index.js
+++ b/src/components/Bean/Form/index.js
@@ -98,8 +98,6 @@ export default function Form({ register, errors, onSubmit }) {
           subtitle='Add more fine-grained information'
           register={register}
           data={[
-            // price
-            // altitude
             {
               name: 'process',
               type: 'text',
@@ -119,6 +117,7 @@ export default function Form({ register, errors, onSubmit }) {
             {
               name: 'price',
               type: 'number',
+              step: '0.01',
               label: 'Price',
               isOptional: true,
               className: 'input pr-11',

--- a/src/components/Bean/Schema.js
+++ b/src/components/Bean/Schema.js
@@ -20,7 +20,7 @@ export const schema = object().shape({
     .transform((value) => (value === '' ? null : value)),
   price: number()
     .nullable(true)
-    .min(0)
+    .positive()
     .transform((value) => (isNaN(value) ? null : value)),
   altitude: number()
     .nullable(true)

--- a/src/components/BrewLog/Detail/index.js
+++ b/src/components/BrewLog/Detail/index.js
@@ -91,16 +91,16 @@ export const Description = ({
           {recipe.bean_name_free ? recipe.bean_name_free : 'N/A'}
         </DataSection>
         <DataSection className='sm:col-span-1' label='Bean Weight'>
-          {recipe.bean_weight}g
+          {recipe.bean_weight} g
         </DataSection>
         <DataSection className='sm:col-span-1' label='Bean Grind'>
           {recipe.bean_grind}
         </DataSection>
         <DataSection className='sm:col-span-1' label='Water Amount'>
-          {recipe.water_amount}g
+          {recipe.water_amount} g
         </DataSection>
         <DataSection className='sm:col-span-1' label='Water Temp'>
-          {recipe.water_temp}F
+          {recipe.water_temp} {'\u00b0C'}
         </DataSection>
         <DataSection className='sm:col-span-1' label='Device'>
           {recipe.device ? recipe.device : 'N/A'}

--- a/src/components/BrewLog/Form/RecipeSection.js
+++ b/src/components/BrewLog/Form/RecipeSection.js
@@ -32,16 +32,16 @@ const RecipeSection = ({
       {bean_name_free ? bean_name_free : 'N/A'}
     </DataSection>
     <DataSection className='sm:col-span-1' label='Bean Weight'>
-      {bean_weight}g
+      {bean_weight} g
     </DataSection>
     <DataSection className='sm:col-span-1' label='Bean Grind'>
       {bean_grind}
     </DataSection>
     <DataSection className='sm:col-span-1' label='Water Amount'>
-      {water_amount}g
+      {water_amount} g
     </DataSection>
     <DataSection className='sm:col-span-1' label='Water Temp'>
-      {water_temp}F
+      {water_temp} {'\u00b0C'}
     </DataSection>
     <DataSection className='sm:col-span-1' label='Device'>
       {device ? device : 'N/A'}

--- a/src/components/Form/Layout/SectionMap.js
+++ b/src/components/Form/Layout/SectionMap.js
@@ -13,6 +13,7 @@ const SectionMap = ({ title, subtitle, register, data }) => (
         defaultValue,
         options,
         rows,
+        step,
         ...rest
       } = input
       const id = createId(input.label)
@@ -47,6 +48,7 @@ const SectionMap = ({ title, subtitle, register, data }) => (
                 className,
                 defaultValue,
                 placeholder,
+                step,
                 ref: register,
               }}
             />

--- a/src/components/Recipe/Detail/index.js
+++ b/src/components/Recipe/Detail/index.js
@@ -27,16 +27,16 @@ export const Description = ({
       {bean_name_free ? bean_name_free : 'N/A'}
     </DataSection>
     <DataSection className='sm:col-span-1' label='Bean Weight'>
-      {bean_weight}g
+      {bean_weight} g
     </DataSection>
     <DataSection className='sm:col-span-1' label='Bean Grind'>
       {bean_grind}
     </DataSection>
     <DataSection className='sm:col-span-1' label='Water Amount'>
-      {water_amount}g
+      {water_amount} g
     </DataSection>
     <DataSection className='sm:col-span-1' label='Water Temp'>
-      {water_temp}F
+      {water_temp} {'\u00b0C'}
     </DataSection>
     <DataSection className='sm:col-span-1' label='Rating'>
       <Rating


### PR DESCRIPTION
**Addresses #266**

# Changes
- Set celsius for all temperature representation (wrongly showed Fahrenheit prior)
- Use [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) to set currency display &mdash; helps catch all edge cases for float-currency representation