### PR TITLE
Implement "Where to purchase" bean section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-markdown": "^6.0.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.0",
+        "remark-external-links": "^8.0.0",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.3",
         "urql": "^1.11.4",
         "yup": "^0.32.9"
@@ -16224,6 +16225,30 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/remark-external-links": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-8.0.0.tgz",
+      "integrity": "sha512-5vPSX0kHoSsqtdftSHhIYofVINC8qmp0nctkeU9YoJwV3YfiBRiI6cbFRJ0oI/1F9xS+bopXG0m2KS8VFscuKA==",
+      "dependencies": {
+        "extend": "^3.0.0",
+        "is-absolute-url": "^3.0.0",
+        "mdast-util-definitions": "^4.0.0",
+        "space-separated-tokens": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-external-links/node_modules/is-absolute-url": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/remark-parse": {
@@ -35223,6 +35248,25 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "remark-external-links": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-8.0.0.tgz",
+      "integrity": "sha512-5vPSX0kHoSsqtdftSHhIYofVINC8qmp0nctkeU9YoJwV3YfiBRiI6cbFRJ0oI/1F9xS+bopXG0m2KS8VFscuKA==",
+      "requires": {
+        "extend": "^3.0.0",
+        "is-absolute-url": "^3.0.0",
+        "mdast-util-definitions": "^4.0.0",
+        "space-separated-tokens": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "is-absolute-url": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+          "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
+        }
+      }
     },
     "remark-parse": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-markdown": "^6.0.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
+    "remark-external-links": "^8.0.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.3",
     "urql": "^1.11.4",
     "yup": "^0.32.9"

--- a/src/components/Bean/Detail/index.js
+++ b/src/components/Bean/Detail/index.js
@@ -1,3 +1,4 @@
+import ReactMarkdown from 'react-markdown'
 import { Link } from 'react-router-dom'
 import { useState } from 'react'
 import { All, Create, Edit } from 'components/Bean/Review'
@@ -5,6 +6,7 @@ import { Rating } from 'components/Badge'
 import { roundToHalfOrWhole } from 'helper/math'
 import { wordCapitalized } from 'helper/stringHelper'
 import { DataSection } from 'components/Layout/Detail'
+import { externalLinkPlugin } from 'helper/sanitize'
 
 export const Description = ({
   altitude,
@@ -16,6 +18,7 @@ export const Description = ({
   about,
   price,
   bean_reviews_aggregate,
+  purchase_info,
 }) => {
   const formatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -51,8 +54,19 @@ export const Description = ({
           )}
         />
       </DataSection>
-      <DataSection className='sm:col-span-2 whitespace-pre-line' label='About'>
-        {about ? about : 'N/A'}
+      <DataSection className='sm:col-span-2' label='About'>
+        <article className='prose prose-sm prose-indigo text-gray-900'>
+          <ReactMarkdown plugins={externalLinkPlugin}>
+            {about ? about : 'N/A'}
+          </ReactMarkdown>
+        </article>
+      </DataSection>
+      <DataSection className='sm:col-span-2' label='Where to purchase'>
+        <article className='prose prose-sm prose-indigo text-gray-900'>
+          <ReactMarkdown plugins={externalLinkPlugin}>
+            {purchase_info ? purchase_info : 'N/A'}
+          </ReactMarkdown>
+        </article>
       </DataSection>
     </>
   )

--- a/src/components/Bean/Form/index.js
+++ b/src/components/Bean/Form/index.js
@@ -52,6 +52,15 @@ export default function Form({ register, errors, onSubmit }) {
               }),
               placeholder: 'e.g. Salento',
             },
+            {
+              label: 'Where to purchase',
+              name: 'purchase_info',
+              type: 'textarea',
+              isOptional: true,
+              className: 'input',
+              placeholder: 'e.g. Find on brewbean marketplace...',
+              rows: '2',
+            },
           ]}
         />
 

--- a/src/components/Bean/List/index.js
+++ b/src/components/Bean/List/index.js
@@ -75,7 +75,7 @@ export default function List({ beans }) {
                 <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize'>
                   {region}
                 </td>
-                <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-500'>
+                <td className='rounded-r-lg px-6 py-4 whitespace-nowrap text-sm text-gray-500'>
                   <Rating
                     value={roundToHalfOrWhole(
                       bean_reviews_aggregate.aggregate.avg.rating

--- a/src/components/Bean/Schema.js
+++ b/src/components/Bean/Schema.js
@@ -26,4 +26,8 @@ export const schema = object().shape({
     .nullable(true)
     .min(0)
     .transform((value) => (isNaN(value) ? null : value)),
+  purchase_info: string()
+    .nullable(true)
+    .trim()
+    .transform((value) => (value === '' ? null : value)),
 })

--- a/src/components/BrewLog/Detail/index.js
+++ b/src/components/BrewLog/Detail/index.js
@@ -6,6 +6,7 @@ import { DataSection } from 'components/Layout/Detail'
 import { StageSection } from 'components/Stage'
 import { combineClass } from 'helper/stringHelper'
 import { ModifyRow } from 'components/Form/ButtonGroup'
+import { externalLinkPlugin } from 'helper/sanitize'
 
 export const Description = ({
   id,
@@ -114,7 +115,9 @@ export const Description = ({
         </DataSection>
         <DataSection className='sm:col-span-2' label='Instructions'>
           <article className='prose prose-sm prose-indigo text-gray-900'>
-            <ReactMarkdown>{recipe.instructions}</ReactMarkdown>
+            <ReactMarkdown plugins={externalLinkPlugin}>
+              {recipe.instructions}
+            </ReactMarkdown>
           </article>
         </DataSection>
       </dl>

--- a/src/components/BrewLog/Form/RecipeSection.js
+++ b/src/components/BrewLog/Form/RecipeSection.js
@@ -1,6 +1,7 @@
 import ReactMarkdown from 'react-markdown'
 import { DataSection } from 'components/Layout/Detail'
 import { StageSection } from 'components/Stage'
+import { externalLinkPlugin } from 'helper/sanitize'
 
 const RecipeSection = ({
   name,
@@ -52,7 +53,9 @@ const RecipeSection = ({
     </DataSection>
     <DataSection className='sm:col-span-2' label='Instructions'>
       <article className='prose prose-sm prose-indigo text-gray-900'>
-        <ReactMarkdown>{instructions}</ReactMarkdown>
+        <ReactMarkdown plugins={externalLinkPlugin}>
+          {instructions}
+        </ReactMarkdown>
       </article>
     </DataSection>
   </>

--- a/src/components/Recipe/Detail/index.js
+++ b/src/components/Recipe/Detail/index.js
@@ -7,6 +7,7 @@ import { All, Create, Edit } from 'components/Recipe/Review'
 import { DataSection } from 'components/Layout/Detail'
 import { combineClass } from 'helper/stringHelper'
 import { PrivacyIcon } from 'components/Icon'
+import { externalLinkPlugin } from 'helper/sanitize'
 
 export const Description = ({
   brew_type,
@@ -54,7 +55,9 @@ export const Description = ({
     </DataSection>
     <DataSection className='sm:col-span-2' label='Instructions'>
       <article className='prose prose-sm prose-indigo text-gray-900'>
-        <ReactMarkdown>{instructions}</ReactMarkdown>
+        <ReactMarkdown plugins={externalLinkPlugin}>
+          {instructions}
+        </ReactMarkdown>
       </article>
     </DataSection>
   </>

--- a/src/helper/sanitize.js
+++ b/src/helper/sanitize.js
@@ -1,3 +1,5 @@
+import externalLinks from 'remark-external-links'
+
 function convertEmptyStringToNull(obj) {
   let sanitizedObj = {}
   Object.keys(obj).forEach((key) => {
@@ -45,5 +47,15 @@ function checkSchema(schema, obj) {
 
   return result
 }
+
+export const externalLinkPlugin = [
+  [
+    externalLinks,
+    {
+      target: '_blank',
+      rel: ['noopener', 'noreferrer'],
+    },
+  ],
+]
 
 export { convertEmptyStringToNull, checkSchema }

--- a/src/queries/Bean.js
+++ b/src/queries/Bean.js
@@ -21,6 +21,7 @@ export const beanInfo = gql`
     roast_type
     varietal
     date_added
+    purchase_info
     author {
       id
       display_name


### PR DESCRIPTION
**Addresses #271**

# Changes
- Add `purchase_info` to bean query
- Add `purchase_info` to bean forms (create/edit)
- Add markdown capabilities to `purchase_info` to allow linking &mdash; **Note: this allows for spam so we will need to keep an eye on it**
  - #270 mentions my strategy for mitigation - admin tools instead of getting rid of feature
- Add helper library `remark-external-links` to add safer links to our markdown converter via link properties: `target: '_blank' rel='noopener noreferrer'`
  - Applied to markdown conversions in recipe as well
- Fix right side rounded styling for bean list view