### PR TITLE
Change mentions of km to meters

### DIFF
--- a/src/components/Bean/Detail/index.js
+++ b/src/components/Bean/Detail/index.js
@@ -36,7 +36,7 @@ export const Description = ({
         {region}
       </DataSection>
       <DataSection className='sm:col-span-1' label='Altitude'>
-        {altitude ? `${altitude} meters` : 'N/A'}
+        {altitude ? `${altitude} m` : 'N/A'}
       </DataSection>
       <DataSection className='sm:col-span-1' label='Variety'>
         {varietal ? varietal : 'N/A'}

--- a/src/components/Bean/Form/index.js
+++ b/src/components/Bean/Form/index.js
@@ -138,9 +138,9 @@ export default function Form({ register, errors, onSubmit }) {
               type: 'number',
               label: 'Altitude',
               isOptional: true,
-              className: 'input pr-9',
+              className: 'input pr-7',
               placeholder: 'e.g. 1000',
-              symbol: 'meters',
+              symbol: 'm',
             },
           ]}
         />


### PR DESCRIPTION
Simple display change where "km" is switched to meters in Bean/Detail/index.js and Bean/Form/index.js (see issue #275).
This better reflects a more precise representation of current altitude values.