### PR TITLE
Implement privacy workflow for recipe

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,6 @@ import Profile from 'pages/Profile'
 import Reset from 'pages/Reset'
 import Guide from 'pages/Guide'
 import { About, Contact, PrivacyPolicy, Terms, NotFound } from 'pages/Content'
-import Create from 'components/Recipe/Form'
 import BrewLog from 'pages/BrewLog'
 import BeanPage from 'pages/Bean'
 import { load, trackPageview } from 'fathom-client'
@@ -53,9 +52,6 @@ function App() {
       <AuthRoute path='/profile'>
         <Profile />
       </AuthRoute>
-      <ContainerRoute path='/test'>
-        <Create />
-      </ContainerRoute>
       <ContainerRoute path='/about'>
         <About />
       </ContainerRoute>

--- a/src/components/Form/Layout/SectionMap.js
+++ b/src/components/Form/Layout/SectionMap.js
@@ -2,10 +2,11 @@ import { createId } from 'helper/stringHelper'
 import Section from './Section'
 import TwoColumnInput from './TwoColumnInput'
 
-const SectionMap = ({ title, subtitle, register, data }) => (
+const SectionMap = ({ title, subtitle, register, data, children }) => (
   <Section {...{ title, subtitle }}>
     {data.map((input) => {
       const {
+        readOnly,
         name,
         className,
         placeholder,
@@ -20,7 +21,16 @@ const SectionMap = ({ title, subtitle, register, data }) => (
       return (
         <TwoColumnInput key={input.name} htmlFor={id} {...rest}>
           {type === 'select' ? (
-            <select {...{ id, name, className, defaultValue, ref: register }}>
+            <select
+              {...{
+                id,
+                name,
+                className,
+                defaultValue,
+                readOnly,
+                ref: register,
+              }}
+            >
               {options.map(({ value, text }) => (
                 <option key={value} value={value}>
                   {text}
@@ -56,6 +66,7 @@ const SectionMap = ({ title, subtitle, register, data }) => (
         </TwoColumnInput>
       )
     })}
+    {children}
   </Section>
 )
 

--- a/src/components/Recipe/Form/index.js
+++ b/src/components/Recipe/Form/index.js
@@ -4,8 +4,10 @@ import { Section, SectionMap } from 'components/Form/Layout'
 import { combineClass } from 'helper/stringHelper'
 import { Create as CreatePlayerStages } from 'components/Player/Form'
 import PlayerInfo from './PlayerInfo'
+import { ExclamationCircleIcon } from '@heroicons/react/outline'
 
 export default function Form({
+  watch,
   register,
   control,
   errors,
@@ -16,6 +18,7 @@ export default function Form({
   preload,
   onCancel,
   header,
+  publicLocked,
 }) {
   const [formMounted, setFormMounted] = useState(
     preload?.formMounted ? preload.formMounted : false
@@ -48,6 +51,13 @@ export default function Form({
   const onEdit = () => {
     setIsHidden(false)
   }
+
+  // select options always strings
+  const watchIsPrivate = watch('is_private')
+  const isPrivate =
+    typeof watchIsPrivate === 'boolean'
+      ? watchIsPrivate
+      : watchIsPrivate === 'true'
 
   return (
     <form onSubmit={onSubmit} className='mt-2 sm:mt-0 space-y-6 sm:space-y-5'>
@@ -235,18 +245,31 @@ export default function Form({
           register={register}
           data={[
             {
+              readOnly: publicLocked,
               label: 'Privacy',
               name: 'is_private',
-              className: 'input',
+              className: combineClass('input', {
+                'pointer-events-none opacity-50': publicLocked,
+              }),
               type: 'select',
-              defaultValue: false,
               options: [
-                { value: false, text: 'Public' },
                 { value: true, text: 'Private' },
+                { value: false, text: 'Public' },
               ],
             },
           ]}
-        />
+        >
+          {!isPrivate && (
+            <div className='mt-1 flex items-center text-yellow-600'>
+              <ExclamationCircleIcon className='w-5 h-5' />
+              <p className='ml-1 text-sm'>
+                {publicLocked
+                  ? 'Privacy is locked as public.'
+                  : 'Note: once a recipe is set as public, it cannot be set back to private'}
+              </p>
+            </div>
+          )}
+        </SectionMap>
       </div>
 
       {/* Button row */}

--- a/src/helper/error.js
+++ b/src/helper/error.js
@@ -21,3 +21,38 @@ export const authenticateError = (addAlert, error) => {
     })
   }
 }
+
+const createError = (addAlert, error, setError, inputField, message) => {
+  if (error.message.includes('Uniqueness violation')) {
+    setError(inputField, {
+      message,
+      shouldFocus: true,
+    })
+  } else {
+    addAlert({
+      type: alertType.ERROR,
+      header: error.message,
+      close: true,
+    })
+  }
+}
+
+export const recipeError = (addAlert, error, setError) => {
+  createError(
+    addAlert,
+    error,
+    setError,
+    'name',
+    'This recipe name already exist'
+  )
+}
+
+export const brewLogError = (addAlert, error, setError) => {
+  createError(
+    addAlert,
+    error,
+    setError,
+    'title',
+    'This brew log title already exist'
+  )
+}

--- a/src/helper/recipe.js
+++ b/src/helper/recipe.js
@@ -7,3 +7,11 @@ export const addServeToStages = (stages, serveTime) => [
     weight: stages[stages.length - 1].weight,
   },
 ]
+
+export const normalizeStages = (stages, serve, recipeId) =>
+  stages
+    ? addServeToStages(stages, serve).map((s) => ({
+        ...s,
+        recipe_id: recipeId,
+      }))
+    : [] // change 'null' to empty array to add no new stages; old stages get deleted regardless

--- a/src/pages/BrewLog/Create/RecipeForm/Create.js
+++ b/src/pages/BrewLog/Create/RecipeForm/Create.js
@@ -7,8 +7,11 @@ import { Header, Title } from 'components/BrewLog/Form'
 import { schema } from 'components/Recipe/Schema'
 import { addServeToStages } from 'helper/recipe'
 import { BREWLOG_FORM } from 'pages/BrewLog/Create'
+import { useAlert } from 'context/AlertContext'
+import { recipeError } from 'helper/error'
 
 export default function Create({ goBack, goTo, setStore }) {
+  const { addAlert } = useAlert()
   const [, insertRecipe] = useMutation(INSERT_RECIPE)
   const methods = useForm({
     resolver: yupResolver(schema),
@@ -26,11 +29,8 @@ export default function Create({ goBack, goTo, setStore }) {
 
     const { data, error } = await insertRecipe({ object })
 
-    if (error?.message.includes('Uniqueness violation')) {
-      methods.setError('name', {
-        message: 'Recipe name must be unique',
-        shouldFocus: true,
-      })
+    if (error) {
+      recipeError(addAlert, error, methods.setError)
     } else {
       // in case user wants to go back to edit recipe
       setStore({ recipe: data.insert_recipe_one, createdRecipeScratch: true })

--- a/src/pages/BrewLog/Create/TemplateForm/Create.js
+++ b/src/pages/BrewLog/Create/TemplateForm/Create.js
@@ -8,8 +8,11 @@ import { schema } from 'components/Recipe/Schema'
 import { getDefaultValues } from 'components/Utility/Form'
 import { addServeToStages } from 'helper/recipe'
 import { BREWLOG_FORM } from 'pages/BrewLog/Create'
+import { recipeError } from 'helper/error'
+import { useAlert } from 'context/AlertContext'
 
 export default function Create({ goBack, goTo, payload, setStore }) {
+  const { addAlert } = useAlert()
   const [, insertRecipe] = useMutation(INSERT_RECIPE)
   const defaultValues = getDefaultValues(payload, [
     { key: 'name', value: undefined },
@@ -31,11 +34,8 @@ export default function Create({ goBack, goTo, payload, setStore }) {
 
     const { data, error } = await insertRecipe({ object })
 
-    if (error?.message.includes('Uniqueness violation')) {
-      methods.setError('name', {
-        message: 'Recipe name must be unique',
-        shouldFocus: true,
-      })
+    if (error) {
+      recipeError(addAlert, error, methods.setError)
     } else {
       setStore({ recipe: data.insert_recipe_one, createdTemplateRecipe: true }) // in case user wants to go back to edit recipe
       goTo(BREWLOG_FORM, {

--- a/src/pages/BrewLog/Edit/CopyEdit.js
+++ b/src/pages/BrewLog/Edit/CopyEdit.js
@@ -8,13 +8,17 @@ import { schema } from 'components/Recipe/Schema'
 import { getDefaultValues } from 'components/Utility/Form'
 import { addServeToStages } from 'helper/recipe'
 import { BREW_LOG_EDIT } from './index'
+import { useAlert } from 'context/AlertContext'
+import { recipeError } from 'helper/error'
 
 export default function CopyEdit({ goBack, goTo, store }) {
+  const { addAlert } = useAlert()
   const [, insertRecipe] = useMutation(INSERT_RECIPE)
   const defaultValues = getDefaultValues(store.brewLog.recipe, [
     { key: 'name', value: undefined },
     { key: 'is_private', value: true },
   ])
+
   const methods = useForm({
     resolver: yupResolver(schema),
     defaultValues,
@@ -31,11 +35,8 @@ export default function CopyEdit({ goBack, goTo, store }) {
 
     const { data, error } = await insertRecipe({ object })
 
-    if (error?.message.includes('Uniqueness violation')) {
-      methods.setError('name', {
-        message: 'Recipe name must be unique',
-        shouldFocus: true,
-      })
+    if (error) {
+      recipeError(addAlert, error, methods.setError)
     } else {
       goTo(BREW_LOG_EDIT, {
         recipe: data.insert_recipe_one,


### PR DESCRIPTION
**Addresses #264**

# Changes
- **[ 🐛 fix ]** - Brew log edit was only sending edit if title, comment, or rating was changed. Fixed it so that now it will update when just recipe is edited
- Refactored error handling into reusable helpers &mdash; `recipeError`, `brewLogError`
- Add prop `publicLocked` for form so that edit containers will be unable to change `is_private` if it is already public
- Add notification underneath privacy selector to tell user about policy now

# Testing
- Create recipe with both privacy
- Edit recipe to try to change privacy
- Repeat conditions above but in brew log context