### PR TITLE
Add recipe delete and deleted user references

### DIFF
--- a/src/cache/Updates.js
+++ b/src/cache/Updates.js
@@ -114,8 +114,10 @@ export const updates = {
         }
       )
     },
-    delete_recipe_by_pk: (result, args, cache, info) => {
-      cache.invalidate({ __typename: 'recipe', id: args.id })
+    update_recipe_by_pk: (result, args, cache, info) => {
+      if (args._set.is_deleted) {
+        cache.invalidate({ __typename: 'recipe', id: args.pk_columns.id })
+      }
     },
     insert_recipe_review_one: (result, args, cache, info) => {
       let recipeFragment = cache.readFragment(recipeInfo, {

--- a/src/components/BrewLog/Detail/index.js
+++ b/src/components/BrewLog/Detail/index.js
@@ -9,7 +9,6 @@ import { ModifyRow } from 'components/Form/ButtonGroup'
 import { externalLinkPlugin } from 'helper/sanitize'
 
 export const Description = ({
-  id,
   comment,
   title,
   date_created,
@@ -56,15 +55,23 @@ export const Description = ({
         <div className='sm:col-span-2 border-t border-gray-200'></div>
 
         <DataSection className='sm:col-span-1' label='Recipe Name'>
-          <Link
-            className='text-indigo-600 font-medium hover:underline inline-flex items-center'
-            to={'/recipe/' + recipe.id}
-          >
-            {recipe.name}
-          </Link>
+          {recipe.is_deleted ? (
+            recipe.name
+          ) : (
+            <Link
+              className='text-indigo-600 font-medium hover:underline inline-flex items-center'
+              to={'/recipe/' + recipe.id}
+            >
+              {recipe.name}
+            </Link>
+          )}
         </DataSection>
         <DataSection className='sm:col-span-1' label='Author'>
-          {recipe.barista.display_name}
+          {recipe.barista?.display_name ? (
+            recipe.barista?.display_name
+          ) : (
+            <span className='font-medium'>[ DELETED ]</span>
+          )}
         </DataSection>
 
         {template_recipe && (
@@ -78,7 +85,7 @@ export const Description = ({
               </Link>
             </DataSection>
             <DataSection className='sm:col-span-1' label='Template Author'>
-              {template_recipe.barista.display_name}
+              {template_recipe.barista?.display_name}
             </DataSection>
           </>
         )}

--- a/src/components/Recipe/Detail/index.js
+++ b/src/components/Recipe/Detail/index.js
@@ -118,7 +118,7 @@ export const TitleSection = ({
       <h1 className='text-2xl font-bold text-gray-900'>{recipeName}</h1>
       <div className='flex flex-col sm:flex-row'>
         <p className='text-sm font-medium text-gray-500'>
-          Created by {name} on{' '}
+          Created by {name ? name : '[ DELETED ]'} on{' '}
           <time dateTime={dateAdded}>{dateAdded.substring(0, 10)}</time>
         </p>
 

--- a/src/pages/BrewLog/Create/Search.js
+++ b/src/pages/BrewLog/Create/Search.js
@@ -110,7 +110,7 @@ export default function Search({ goBack, goTo }) {
           <RecipeRow
             key={r.id}
             recipeName={r.name}
-            displayName={r.barista.display_name}
+            displayName={r.barista ? r.barista.display_name : '[ DELETED ]'}
             onImport={goToImport(r)}
             onTemplate={goToTemplate(r)}
           />

--- a/src/pages/BrewLog/Detail/index.js
+++ b/src/pages/BrewLog/Detail/index.js
@@ -7,10 +7,12 @@ import { Loading } from 'components/Utility'
 import { Description } from 'components/BrewLog/Detail'
 import { useModal } from 'context/ModalContext'
 import { ExclamationCircleIcon } from '@heroicons/react/solid'
+import { setUrqlHeader } from 'helper/header'
 
 export default function Detail() {
   const history = useHistory()
-  let { id } = useParams()
+  const params = useParams()
+  const id = parseInt(params.id)
 
   const { isSuccess, isPending, open, content, setContent, reset } = useModal()
 
@@ -34,15 +36,9 @@ export default function Detail() {
 
   const [{ data, fetching, error }] = useQuery({
     query: GET_BREW_LOG,
-    variables: { id: id ? parseInt(id) : null },
+    variables: { id },
     context: useMemo(
-      () => ({
-        fetchOptions: {
-          headers: {
-            'x-hasura-role': 'all_barista',
-          },
-        },
-      }),
+      () => setUrqlHeader({ 'x-hasura-role': 'all_barista' }),
       []
     ),
   })

--- a/src/pages/Recipe/Edit/index.js
+++ b/src/pages/Recipe/Edit/index.js
@@ -19,7 +19,11 @@ export default function EditRecipe() {
   if (!data?.recipe_by_pk) return null
 
   // needs to be last or else it will always redirect because query is slower
-  if (!isVerified || data?.recipe_by_pk.barista_id !== barista?.id)
+  if (
+    !isVerified ||
+    data.recipe_by_pk.barista_id !== barista?.id ||
+    data.recipe_by_pk.is_deleted
+  )
     return <Redirect to={`/recipe/${id}`} />
 
   return <Container recipe={data.recipe_by_pk} />

--- a/src/pages/Recipe/Player.js
+++ b/src/pages/Recipe/Player.js
@@ -9,7 +9,7 @@ const PlayerContainer = () => {
   const { id } = useParams()
 
   const [{ data, fetching, error }] = useQuery({
-    query: GET_RECIPE,
+    query: GET_RECIPE, // can get to this player page from a brew log with a deleted recipe
     variables: { id },
   })
 

--- a/src/pages/Recipe/Recipe/Table.js
+++ b/src/pages/Recipe/Recipe/Table.js
@@ -67,7 +67,7 @@ export default function Table({ recipes }) {
               >
                 <td className='rounded-l-lg px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900'>
                   <div className='flex items-center'>
-                    {user?.id === barista.id && (
+                    {user?.id === barista?.id && (
                       <PrivacyIcon
                         isPrivate={is_private}
                         className='h-5 w-5 mr-3 text-gray-700'
@@ -82,12 +82,14 @@ export default function Table({ recipes }) {
                   </div>
                 </td>
                 <td className='px-6 py-4 whitespace-nowrap text-xs font-medium text-gray-500'>
-                  {user?.display_name === barista.display_name ? (
+                  {user?.display_name === barista?.display_name ? (
                     <TextSymbol symbol={UserIcon}>
-                      {barista.display_name}
+                      {user?.display_name}
                     </TextSymbol>
-                  ) : (
+                  ) : barista ? (
                     barista.display_name
+                  ) : (
+                    '[ DELETED ]'
                   )}
                 </td>
                 <td className='px-6 py-4 whitespace-nowrap text-xs font-medium text-gray-500 capitalize'>

--- a/src/queries/Recipe.js
+++ b/src/queries/Recipe.js
@@ -35,6 +35,7 @@ export const recipeInfo = gql`
     name
     instructions
     bean_name_free
+    is_deleted
     stages {
       id
       action
@@ -79,10 +80,15 @@ export const INSERT_RECIPE = gql`
 `
 export const GET_ALL_RECIPES = gql`
   query GetAllRecipes($limit: Int, $offset: Int) {
-    recipe(order_by: { id: desc }, limit: $limit, offset: $offset) {
+    recipe(
+      order_by: { id: desc }
+      where: { is_deleted: { _eq: false } }
+      limit: $limit
+      offset: $offset
+    ) {
       ...RecipeInfo
     }
-    recipe_aggregate {
+    recipe_aggregate(where: { is_deleted: { _eq: false } }) {
       aggregate {
         count
       }
@@ -109,11 +115,15 @@ export const UPDATE_RECIPE_REVIEW = gql`
   ${recipeReviewInfo}
 `
 export const DELETE_RECIPE = gql`
-  mutation DeleteRecipe($id: Int!) {
-    delete_recipe_by_pk(id: $id) {
-      id
+  mutation DeleteRecipe($id: Int!, $name: String!) {
+    update_recipe_by_pk(
+      pk_columns: { id: $id }
+      _set: { name: $name, is_deleted: true }
+    ) {
+      ...RecipeInfo
     }
   }
+  ${recipeInfo}
 `
 /*
   Recipe Review Queries


### PR DESCRIPTION
**Implements #259**

# Changes
- Allows **soft delete** now by adding a `is_deleted` boolean field to recipe table &mdash; https://github.com/brewbean/graphql/pull/34
- Update queries to filter out `is_deleted` recipes
- Double checked that these recipes could still be referenced by brew logs
- Cache updates still remove soft deleted recipes
- Recipes that are soft deleted cannot go to `/recipe/{id}` nor `/recipe/{id}/edit`, but recipe player still works so brew log can use it

# Side changes
- Realized there is a similar challenge for having brew log and recipes list content created by a deleted user
- Implemented changes for this situation, **but still need to implement this for bean** &mdash; _**let's cut a ticket for @CameronNLee to do this (good first issue)**_
- Now renders `[ DELETED ]` for content from deleted user

# Testing
- Create recipes & delete them. They should disappear from `/recipe` table
- Create brew logs referencing a recipe. Delete recipe. Brew log should be stable
- Create brew log referencing a recipe by another user. Delete their recipe. Brew log should be stable.
- Create brew log referencing a recipe by another user. **Delete the user**. Brew log should be stable

**Example of deleted user styling**
![Screen Shot 2021-04-22 at 4 48 29 PM](https://user-images.githubusercontent.com/6396042/115798878-2a93a480-a38c-11eb-8234-701fa110bdc0.png)
![Screen Shot 2021-04-22 at 4 48 39 PM](https://user-images.githubusercontent.com/6396042/115798883-2b2c3b00-a38c-11eb-9b00-8663c16cc8fb.png)
![Screen Shot 2021-04-22 at 4 52 52 PM](https://user-images.githubusercontent.com/6396042/115798885-2bc4d180-a38c-11eb-9392-9c4258b7fa96.png)
