### PR TITLE
Implement bean search & sort/filter

### DIFF
--- a/src/cache/Updates.js
+++ b/src/cache/Updates.js
@@ -1,3 +1,4 @@
+import { DESC } from 'constants/query'
 import { beanInfo, GET_ALL_BEANS } from 'queries/Bean'
 import { GET_ALL_BREW_LOGS } from 'queries/BrewLog'
 import { GET_ALL_RECIPES, recipeInfo } from 'queries/Recipe'
@@ -21,6 +22,8 @@ export const updates = {
           variables: {
             limit: 10,
             offset: 0,
+            query: '%%',
+            orderBy: { id: DESC },
           },
         },
         (data) => {

--- a/src/components/Bean/List/index.js
+++ b/src/components/Bean/List/index.js
@@ -1,8 +1,29 @@
 import { useHistory, useRouteMatch } from 'react-router-dom'
 import { roundToHalfOrWhole } from 'helper/math'
 import { Rating } from 'components/Badge'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/solid'
+import { combineClass } from 'helper/stringHelper'
+import { ASC } from 'constants/query'
 
-export default function List({ beans }) {
+const Sort = ({ onClick, direction }) => {
+  return (
+    <button
+      onClick={onClick}
+      type='button'
+      className={combineClass('focus:outline-none font-bold rounded-full p-1', {
+        'bg-indigo-100 text-indigo-700': direction,
+      })}
+    >
+      {direction === ASC ? (
+        <ChevronUpIcon className='h-5 w-5' />
+      ) : (
+        <ChevronDownIcon className='h-5 w-5 ' />
+      )}
+    </button>
+  )
+}
+
+export default function List({ beans, sortHandler, filters }) {
   const { url } = useRouteMatch()
   const history = useHistory()
 
@@ -15,31 +36,58 @@ export default function List({ beans }) {
               scope='col'
               className='px-6 py-3 text-left text-sm font-medium text-gray-600'
             >
-              Name
+              <div className='flex justify-between items-center'>
+                Name
+                <Sort direction={filters.name} onClick={sortHandler('name')} />
+              </div>
             </th>
             <th
               scope='col'
               className='px-6 py-3 text-left text-sm font-medium text-gray-600'
             >
-              Company
+              <div className='flex justify-between items-center'>
+                Company
+                <Sort
+                  direction={filters.company_name}
+                  onClick={sortHandler('company_name')}
+                />
+              </div>
             </th>
             <th
               scope='col'
               className='px-6 py-3 text-left text-sm font-medium text-gray-600'
             >
-              Roast
+              <div className='flex justify-between items-center'>
+                Roast
+                <Sort
+                  direction={filters.roast_type}
+                  onClick={sortHandler('roast_type')}
+                />
+              </div>
             </th>
             <th
               scope='col'
               className='px-6 py-3 text-left text-sm font-medium text-gray-600'
             >
-              Region
+              <div className='flex justify-between items-center'>
+                Region
+                <Sort
+                  direction={filters.region}
+                  onClick={sortHandler('region')}
+                />
+              </div>
             </th>
             <th
               scope='col'
               className='px-6 py-3 text-left text-sm font-medium text-gray-600'
             >
-              Rating
+              <div className='flex justify-between items-center'>
+                Rating
+                <Sort
+                  direction={filters.bean_reviews_aggregate?.avg.rating}
+                  onClick={sortHandler('bean_reviews_aggregate')}
+                />
+              </div>
             </th>
           </tr>
         </thead>

--- a/src/components/Utility/Loading.js
+++ b/src/components/Utility/Loading.js
@@ -1,5 +1,5 @@
 const Loading = ({
-  sizeClass = 'h-5 w-5',
+  className = 'h-5 w-5 text-indigo-600',
   defaultPadding = true,
   containerClass = '',
 }) => {
@@ -7,7 +7,7 @@ const Loading = ({
   return (
     <div className={defaultPadding ? containerBase + ' p-5' : containerBase}>
       <svg
-        className={'animate-spin text-indigo-600 ' + sizeClass}
+        className={'animate-spin ' + className}
         xmlns='http://www.w3.org/2000/svg'
         fill='none'
         viewBox='0 0 24 24'

--- a/src/constants/query.js
+++ b/src/constants/query.js
@@ -1,0 +1,2 @@
+export const DESC = 'desc_nulls_last'
+export const ASC = 'asc_nulls_last'

--- a/src/pages/Activate/index.js
+++ b/src/pages/Activate/index.js
@@ -81,7 +81,7 @@ function Activate() {
       <div className='px-4 py-5 sm:p-8'>
         <div className='pb-5'>
           {isLoading ? (
-            <Loading sizeClass='h-12 w-12' defaultPadding={false} />
+            <Loading className='h-12 w-12' defaultPadding={false} />
           ) : isSuccess ? (
             <div className='mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100'>
               <svg

--- a/src/queries/Bean.js
+++ b/src/queries/Bean.js
@@ -76,11 +76,37 @@ export const UPDATE_BEAN = gql`
 `
 
 export const GET_ALL_BEANS = gql`
-  query GetAllBeans($limit: Int, $offset: Int) {
-    bean(order_by: { id: desc }, limit: $limit, offset: $offset) {
+  query GetAllBeans(
+    $limit: Int
+    $offset: Int
+    $query: String
+    $orderBy: [bean_order_by!]
+  ) {
+    bean(
+      order_by: $orderBy
+      limit: $limit
+      offset: $offset
+      where: {
+        _or: [
+          { name: { _ilike: $query } }
+          { company_name: { _ilike: $query } }
+          { roast_type: { _ilike: $query } }
+          { region: { _ilike: $query } }
+        ]
+      }
+    ) {
       ...BeanInfo
     }
-    bean_aggregate {
+    bean_aggregate(
+      where: {
+        _or: [
+          { name: { _ilike: $query } }
+          { company_name: { _ilike: $query } }
+          { roast_type: { _ilike: $query } }
+          { region: { _ilike: $query } }
+        ]
+      }
+    ) {
       aggregate {
         count
       }


### PR DESCRIPTION
**Addresses #213**

# Changes
### Sort
- Default is to sort entries by `id` descending; this is same as newest to oldest
- Press down chevron button once - sort by field descending (null last)
- Press again - sort by field ascending (null last)
- Press again - remove field from sort (default sort)
### Search
- [hasura reference](https://hasura.io/blog/full-text-search-with-hasura-graphql-api-postgres/)
- use `%%` to match characters &mdash; from reference `% sign is used to pattern match any sequence of zero or more characters.`
- Deleting all characters in search bar triggers a refetch of default search (nothing) &mdash; **should hit cache**