### PR TITLE
Fix lingering alert on bean/recipe create

### DIFF
--- a/src/pages/Bean/Create/index.js
+++ b/src/pages/Bean/Create/index.js
@@ -31,7 +31,8 @@ export default function CreateBean() {
     }
   }
 
-  if (!location.state || !isAuthenticated) return <Redirect to='/bean' />
+  if (!location.state?.fromBean || !isAuthenticated)
+    return <Redirect to='/bean' />
 
   return <Form {...methods} onSubmit={methods.handleSubmit(submitBean)} />
 }

--- a/src/pages/Bean/Main/index.js
+++ b/src/pages/Bean/Main/index.js
@@ -30,7 +30,7 @@ export default function Main() {
     reset,
   } = useModal()
   const { url } = useRouteMatch()
-  const { addAlert } = useAlert()
+  const { addAlert, clearAlerts } = useAlert()
   const location = useLocation()
   const history = useHistory()
   const { page } = qs.parse(location.search, { ignoreQueryPrefix: true })
@@ -73,6 +73,7 @@ export default function Main() {
 
   const navigateToCreate = () => {
     if (isVerified) {
+      clearAlerts()
       history.push(`${url}/new`, { fromBean: true })
     } else if (isAuthenticated) {
       triggerUnverifiedModal()
@@ -128,9 +129,19 @@ export default function Main() {
       // need to clear modal settings so that going back
       // to this page doesn't retrigger this effect
       reset()
-      history.push(`${url}/new`, { fromRecipe: true })
+      clearAlerts()
+      history.push(`${url}/new`, { fromBean: true })
     }
-  }, [isPending, isSuccess, content, isVerified, url, history, reset])
+  }, [
+    isPending,
+    isSuccess,
+    content,
+    isVerified,
+    url,
+    history,
+    reset,
+    clearAlerts,
+  ])
 
   if (error) return <p>Oh no... {error.message}</p>
 

--- a/src/pages/Recipe/Create/index.js
+++ b/src/pages/Recipe/Create/index.js
@@ -46,7 +46,8 @@ export default function CreateRecipe() {
     }
   }
 
-  if (!location.state || !isAuthenticated) return <Redirect to='/recipe' />
+  if (!location.state?.fromRecipe || !isAuthenticated)
+    return <Redirect to='/recipe' />
 
   return (
     <Form

--- a/src/pages/Recipe/Recipe/index.js
+++ b/src/pages/Recipe/Recipe/index.js
@@ -24,7 +24,7 @@ const Recipes = () => {
     reset,
   } = useModal()
   const { url } = useRouteMatch()
-  const { addAlert } = useAlert()
+  const { addAlert, clearAlerts } = useAlert()
   const location = useLocation()
   const history = useHistory()
   const { page } = qs.parse(location.search, { ignoreQueryPrefix: true })
@@ -61,6 +61,7 @@ const Recipes = () => {
 
   const navigateToCreate = () => {
     if (isVerified) {
+      clearAlerts()
       history.push(`${url}/new`, { fromRecipe: true })
     } else if (isAuthenticated) {
       triggerUnverifiedModal()
@@ -75,9 +76,19 @@ const Recipes = () => {
       // need to clear modal settings so that going back
       // to this page doesn't retrigger this effect
       reset()
+      clearAlerts()
       history.push(`${url}/new`, { fromRecipe: true })
     }
-  }, [isPending, isSuccess, content, isVerified, url, history, reset])
+  }, [
+    isPending,
+    isSuccess,
+    content,
+    isVerified,
+    url,
+    history,
+    reset,
+    clearAlerts,
+  ])
 
   if (fetching) return <Loading />
   if (error) return <ErrorMessage message={error.message} />


### PR DESCRIPTION
**Addresses #298**

# Changes
- Noticed bug also happened on `/bean` so same fix applied there
- Issue is alerts are not automatically cleared when you navigate between locations with a `state` value. The reason is because of the rendering lifecycle where setting a `state` would then trigger a clear alert when it wasn't wanted
  - **This overall conflict of rendering lifecycle with navigation and alert context is something I want to refactor in future**
- Since alerts aren't automatically cleared when navigating with a `location.state`, I added manual `clearAlerts` call on navigating to `/{recipe || bean}/create`