### PR TITLE
fixed wrong display values when no brew log entries exist

### DIFF
--- a/src/pages/BrewLog/Main/MobileWelcome.js
+++ b/src/pages/BrewLog/Main/MobileWelcome.js
@@ -10,6 +10,7 @@ export default function MobileWelcome({ fetching, error, data, goToCreate }) {
   const { page } = useQueryParams()
   const currPage = page ? parseInt(page) : 1
   const offset = (currPage - 1) * 10
+  const start = (data?.brew_log.length != 0) ? 1 : 0
 
   return (
     <>
@@ -40,7 +41,7 @@ export default function MobileWelcome({ fetching, error, data, goToCreate }) {
 
         <div className='py-4 px-6'>
           <BasicPagination
-            start={1 + offset}
+            start={start + offset}
             end={data?.brew_log.length + offset}
             total={data?.brew_log_aggregate?.aggregate?.count}
           />

--- a/src/pages/BrewLog/Main/index.js
+++ b/src/pages/BrewLog/Main/index.js
@@ -13,6 +13,7 @@ export default function Main({ fetching, error, data, goToCreate }) {
   const { page } = useQueryParams()
   const currPage = page ? parseInt(page) : 1
   const offset = (currPage - 1) * 10
+  const start = (data?.brew_log.length != 0) ? 1 : 0
 
   return (
     <div className='bg-gray-100'>
@@ -55,7 +56,7 @@ export default function Main({ fetching, error, data, goToCreate }) {
                 {/* Pagination controls */}
                 <div className='flex-shrink-0 h-16 px-6 flex flex-col justify-center border-t border-gray-200'>
                   <BasicPagination
-                    start={1 + offset}
+                    start={start + offset}
                     end={data?.brew_log.length + offset}
                     total={data?.brew_log_aggregate?.aggregate?.count}
                   />


### PR DESCRIPTION
Addresses issue #289. The problem was that there was no check for when there are no brew log entries, so in that event, the values shown are 1 - 0 of 0.

## Implementation

- Two files affected: ``pages/BrewLog/Main/index.js``  and ``pages/BrewLog/Main/MobileWelcome.js``
- for both, simply add a ternary check for the ``start`` variable before it gets passed into ``BasicPagination`` as an argument:
- if there are no brew log entries, set ``start`` to 0, otherwise 1.
- proceed by passing in ``start`` + ``offset`` to ``BasicPagination``. here, ``start`` now can be either 0 or 1, not just 1 like previously which was causing the bug to occur.

## Testing Example
start with an empty brewlog. above change is reflected: values now show 0 - 0 of 0 instead of 1 - 0 of 1
![1](https://user-images.githubusercontent.com/18453388/116486367-4f7f9000-a842-11eb-86a0-318527b5aef6.PNG)

Continue testing by adding more brew logs to make sure counter displays correctly onwards:
![2](https://user-images.githubusercontent.com/18453388/116486434-70e07c00-a842-11eb-8b64-e80eaccd99e2.PNG)

First case: 1 - 1 to 1 after adding 1 brew log entry:
![3](https://user-images.githubusercontent.com/18453388/116486444-7dfd6b00-a842-11eb-934d-ddab68451956.PNG)

Second case: 1 - 4 to 4 after adding 4 brew log entries:
![4](https://user-images.githubusercontent.com/18453388/116486452-835ab580-a842-11eb-9be8-b8398693c112.PNG)

Third case: testing offset and page count math
![5](https://user-images.githubusercontent.com/18453388/116486467-8fdf0e00-a842-11eb-93bc-bb19cb741e03.PNG)

Fourth case: testing new page values.
![6](https://user-images.githubusercontent.com/18453388/116486493-a2594780-a842-11eb-94e6-931be8d28329.PNG)

And so on and so forth...
![7](https://user-images.githubusercontent.com/18453388/116486519-b13ffa00-a842-11eb-89f3-b25c1702d461.PNG)
![8](https://user-images.githubusercontent.com/18453388/116486527-b735db00-a842-11eb-8292-ec311721d566.PNG)

Note: Deleting all brew log entries reverts the display back to 0 - 0 of 0 as expected.