### PR TITLE
[ brew log ] add null check for brewlog rating

### DIFF
--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -10,7 +10,7 @@ export const Rating = ({ value }) => (
         : 'bg-red-200 text-red-800'
     }`}
   >
-    {value ? value : 'not rated'}
+    {value !== null ? value : 'not rated'}
   </span>
 )
 


### PR DESCRIPTION
Addresses issue #288.

### Implementation
- affected file: ``components/Badge/index.js``
- conditional check for ``value`` has it treating 0 as equivalent to ``false``, thus entering the ``else`` part of the ternary and giving us 'not rated', which we did not want if we are allowing for ratings to be 0.
- instead, have the ternary check if rating is a non-null value. if so, display the value, otherwise display 'not rated'
- this allows for 0 to display rather than 'not rated' since 0 is not considered null. Modified line seen here:
![1](https://user-images.githubusercontent.com/18453388/117064089-93f3ab80-acda-11eb-88b0-5c0a4a37d278.PNG)

### Testing
- sign in > brew logs > + > create or import recipe > give 0 rating
- 0 should now show up as 0 instead of 'not rated'
- other rating behavior not affected and still working as intended
![2](https://user-images.githubusercontent.com/18453388/117064554-301db280-acdb-11eb-8d6c-a220e08100db.PNG)

### Side Note
- affects brew log ratings only; creating your own beans and rating them 0 still shows 'not rated'
- Found this out while testing; not sure if this has been mentioned before: where editing a brew log entry you just made, and then changing the rating value from the previous value, this happens:
![3](https://user-images.githubusercontent.com/18453388/117065487-70316500-acdc-11eb-9141-2d8868842ac3.PNG)

- on the actual brewbean website, this only shows up in browser inspector console, but it also doesn't let you submit your newly edited brewlog either.